### PR TITLE
fix: remove Amplitude as dependency for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "Amplitude", url: "https://github.com/amplitude/Amplitude-iOS", from: "8.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
* Remove Amplitude dependency from Package.swift
    - This one fell through the cracks when updating from beta SDK

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
