### PR TITLE
feat: add automatic background retries to fetch

### DIFF
--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */; };
+		20B1BB8E2683CC2A003A960F /* Backoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BB8D2683CC2A003A960F /* Backoff.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
 		E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E914961D25796DA800C64B38 /* ExperimentClientTests.swift */; };
@@ -35,6 +36,7 @@
 
 /* Begin PBXFileReference section */
 		201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentUserTests.swift; sourceTree = "<group>"; };
+		20B1BB8D2683CC2A003A960F /* Backoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backoff.swift; sourceTree = "<group>"; };
 		E9030DB425B8AFC600BA1BA8 /* Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variant.swift; sourceTree = "<group>"; };
 		E914960F25796DA800C64B38 /* Experiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Experiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E914961225796DA800C64B38 /* Experiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Experiment.h; sourceTree = "<group>"; };
@@ -112,9 +114,10 @@
 				E9C5D9132579718E00867574 /* ExperimentClient.swift */,
 				E9C5D9152579718E00867574 /* ExperimentConfig.swift */,
 				E9C5D9162579718E00867574 /* ExperimentUser.swift */,
+				20B1BB8D2683CC2A003A960F /* Backoff.swift */,
+				E9030DB425B8AFC600BA1BA8 /* Variant.swift */,
 				E914961225796DA800C64B38 /* Experiment.h */,
 				E914961325796DA800C64B38 /* Info.plist */,
-				E9030DB425B8AFC600BA1BA8 /* Variant.swift */,
 			);
 			path = Experiment;
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 				E9C5D91D2579718E00867574 /* UserDefaultsStorage.swift in Sources */,
 				E9C5D9222579718E00867574 /* Storage.swift in Sources */,
 				E9C5D9212579718E00867574 /* InMemoryStorage.swift in Sources */,
+				20B1BB8E2683CC2A003A960F /* Backoff.swift in Sources */,
 				E9C5D91B2579718E00867574 /* DefaultUserProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Experiment/Backoff.swift
+++ b/Sources/Experiment/Backoff.swift
@@ -1,0 +1,85 @@
+//
+//  Backoff.swift
+//  Experiment
+//
+//  Created by Brian Giori on 6/23/21.
+//
+
+import Foundation
+
+internal class Backoff {
+
+    // Configuration
+    private let attempts: Int
+    private let min: Int
+    private let max: Int
+    private let scalar: Float
+
+    // Dispatch
+    private let lock = DispatchSemaphore(value: 1)
+    private let fetchQueue = DispatchQueue(label: "com.amplitude.experiment.fetch.backoff", qos: .background)
+
+    // State
+    private var started: Bool = false
+    private var cancelled: Bool = false
+    private var fetchTask: URLSessionTask? = nil
+
+    init(attempts: Int, min: Int, max: Int, scalar: Float) {
+        self.attempts = attempts
+        self.min = min
+        self.max = max
+        self.scalar = scalar
+    }
+
+    func start(
+        function: @escaping ( @escaping (Error?) -> Void) -> URLSessionTask?
+    ) {
+        lock.wait()
+        defer { lock.signal() }
+        if started {
+            return
+        }
+        self.backoff(attempt: 0, delay: self.min, function: function)
+    }
+
+    func cancel() {
+        self.fetchQueue.sync { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if !self.cancelled {
+                self.fetchTask?.cancel()
+                self.cancelled = true
+            }
+        }
+    }
+
+    private func backoff(
+        attempt: Int,
+        delay: Int,
+        function: @escaping ( @escaping (Error?) -> Void) -> URLSessionTask?
+    ) {
+        fetchQueue.asyncAfter(deadline: .now() + .milliseconds(delay)) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if self.cancelled {
+                return
+            }
+            self.fetchTask = function() { error in
+                guard error != nil else {
+                    // Success
+                    print("[Experiment] Retry success")
+                    return
+                }
+                print("[Experiment] Retry failure")
+                // Retry the request function
+                let nextAttempt = attempt + 1
+                if nextAttempt < self.attempts {
+                    let nextDelay = Int(Swift.min(Float(delay) * self.scalar, Float(self.max)))
+                    self.backoff(attempt: nextAttempt, delay: nextDelay, function: function);
+                }
+            }
+        }
+    }
+}

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -20,7 +20,8 @@ public struct ExperimentConfig {
     public private(set) var source: Source = ExperimentConfig.Defaults.source
     public private(set) var serverUrl: String = ExperimentConfig.Defaults.serverUrl
     public private(set) var fetchTimeoutMillis: Int = ExperimentConfig.Defaults.fetchTimeoutMillis
-    
+    public private(set) var retryFetchOnFailure: Bool = ExperimentConfig.Defaults.retryFetchOnFailure
+
     public init() {
         // Default Config
     }
@@ -32,6 +33,7 @@ public struct ExperimentConfig {
         static let source: Source = Source.LocalStorage
         static let serverUrl: String = "https://api.lab.amplitude.com"
         static let fetchTimeoutMillis: Int = 10000
+        static let retryFetchOnFailure: Bool = true
     }
     
     public class Builder {
@@ -72,6 +74,11 @@ public struct ExperimentConfig {
             return self
         }
         
+        public func fetchRetryOnFailure(_ fetchRetryOnFailure: Bool) -> Builder {
+            config.retryFetchOnFailure = fetchRetryOnFailure
+            return self
+        }
+
         public func build() -> ExperimentConfig {
             return config
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

* Add automatic retries in the background if the initial fetch request fails
   - same behavior as experiment-js-client SDK

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
