### PR TITLE
feat: set DefaultUserProvider by default

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -26,7 +26,7 @@ public class DefaultExperimentClient : ExperimentClient {
     private let config: ExperimentConfig
     
     private var user: ExperimentUser? = nil
-    private var userProvider: ExperimentUserProvider? = nil
+    private var userProvider: ExperimentUserProvider? = DefaultUserProvider()
 
     internal init(apiKey: String, config: ExperimentConfig, storage: Storage) {
         self.apiKey = apiKey


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->'

* Set the DefaultUserProvider in the client by default

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
