### PR TITLE
fix: fix variant encoding/decoding from storage

### DIFF
--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */; };
 		20B1BB8E2683CC2A003A960F /* Backoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BB8D2683CC2A003A960F /* Backoff.swift */; };
+		20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BF20268BBDA4003A960F /* VariantTests.swift */; };
+		20B1BF2B268BFFD7003A960F /* UserDefaultsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BF2A268BFFD7003A960F /* UserDefaultsStorageTests.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
 		E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E914961D25796DA800C64B38 /* ExperimentClientTests.swift */; };
@@ -37,6 +39,8 @@
 /* Begin PBXFileReference section */
 		201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentUserTests.swift; sourceTree = "<group>"; };
 		20B1BB8D2683CC2A003A960F /* Backoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backoff.swift; sourceTree = "<group>"; };
+		20B1BF20268BBDA4003A960F /* VariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantTests.swift; sourceTree = "<group>"; };
+		20B1BF2A268BFFD7003A960F /* UserDefaultsStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorageTests.swift; sourceTree = "<group>"; };
 		E9030DB425B8AFC600BA1BA8 /* Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variant.swift; sourceTree = "<group>"; };
 		E914960F25796DA800C64B38 /* Experiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Experiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E914961225796DA800C64B38 /* Experiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Experiment.h; sourceTree = "<group>"; };
@@ -125,9 +129,11 @@
 		E914961C25796DA800C64B38 /* ExperimentTests */ = {
 			isa = PBXGroup;
 			children = (
-				E914961D25796DA800C64B38 /* ExperimentClientTests.swift */,
 				E914961F25796DA800C64B38 /* Info.plist */,
+				E914961D25796DA800C64B38 /* ExperimentClientTests.swift */,
 				201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */,
+				20B1BF20268BBDA4003A960F /* VariantTests.swift */,
+				20B1BF2A268BFFD7003A960F /* UserDefaultsStorageTests.swift */,
 			);
 			path = ExperimentTests;
 			sourceTree = "<group>";
@@ -279,8 +285,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20B1BF2B268BFFD7003A960F /* UserDefaultsStorageTests.swift in Sources */,
 				201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */,
 				E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */,
+				20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Experiment/UserDefaultsStorage.swift
+++ b/Sources/Experiment/UserDefaultsStorage.swift
@@ -34,29 +34,23 @@ internal class UserDefaultsStorage: Storage {
     }
 
     func load() {
-        if
-            let data = userDefaults.value(forKey: self.key) as? Data,
-            let loaded = try? JSONDecoder().decode([String:Variant].self, from: data) {
+        do {
+            let data = userDefaults.value(forKey: self.key) as! Data
+            let loaded = try JSONDecoder().decode([String:Variant].self, from: data)
             for (key, value) in loaded {
                 map[key] = value
             }
-            return
-        }
-
-        if
-            let loaded = userDefaults.dictionary(forKey: self.key) as? [String:String] {
-            for (key, value) in loaded {
-                map[key] = Variant(value)
-            }
-            return
+        } catch {
+            print("[Experiment] load failed: \(error)")
         }
     }
 
     func save() {
-        if let data = try? JSONEncoder().encode(map) {
+        do {
+            let data = try JSONEncoder().encode(map)
             userDefaults.set(data, forKey: self.key)
+        } catch {
+            print("[Experiment] save failed: \(error)")
         }
     }
-
-
 }

--- a/Sources/Experiment/Variant.swift
+++ b/Sources/Experiment/Variant.swift
@@ -77,9 +77,3 @@ extension Variant : Equatable {
         return lhsData == rhsData
     }
 }
-
-extension Variant {
-    internal func toJson() throws -> Data {
-        return try JSONSerialization.data(withJSONObject: self, options: [])
-    }
-}

--- a/Tests/ExperimentTests/UserDefaultsStorageTests.swift
+++ b/Tests/ExperimentTests/UserDefaultsStorageTests.swift
@@ -1,0 +1,64 @@
+//
+//  UserDefaultsTests.swift
+//  ExperimentTests
+//
+//  Created by Brian Giori on 6/29/21.
+//
+
+import XCTest
+@testable import Experiment
+
+let instance = "test"
+let apiKey = "123456"
+let userDefaults = UserDefaults.standard
+let userDefaultsKey = "com.amplituide.experiment.variants.\(instance).\(apiKey)"
+
+class UserDefaultsStorageTests: XCTestCase {
+    
+    let storage = UserDefaultsStorage(instanceName: instance, apiKey: apiKey)
+    let variants: [String: Variant] = [
+        "variant1": Variant("1", payload: 1),
+        "variant2": Variant("2", payload: "2"),
+        "variant3": Variant("3", payload: nil),
+        "variant4": Variant("4", payload: [4, 4, 4]),
+        "variant5": Variant("5", payload: ["k":"v"]),
+        "variant6": Variant("6", payload: true),
+        "variant7": Variant("7", payload: 6.9)
+    ]
+    func testLoadAndGetAll() {
+        preload(variants)
+        storage.load()
+        let storageVariants = storage.getAll()
+        XCTAssertEqual(variants, storageVariants)
+        
+    }
+    
+    func testPutSaveAndGetAll() {
+        for (key, variant) in variants {
+            storage.put(key: key, value: variant)
+        }
+        storage.save()
+        let storageVariants = storage.getAll()
+        XCTAssertEqual(variants, storageVariants)
+        storage.load()
+        let storageVariants2 = storage.getAll()
+        XCTAssertEqual(variants, storageVariants2)
+        XCTAssertEqual(storageVariants, storageVariants2)
+    }
+    
+    func testClear() {
+        preload(variants)
+        storage.load()
+        storage.clear()
+        let empty = storage.getAll()
+        XCTAssertTrue(empty.isEmpty)
+        storage.load()
+        let storageVariants = storage.getAll()
+        XCTAssertEqual(variants, storageVariants)
+    }
+    
+    func preload(_ variants: [String: Variant]) {
+        let data = try! JSONEncoder().encode(variants)
+        userDefaults.set(data, forKey: userDefaultsKey)
+    }
+}

--- a/Tests/ExperimentTests/UserDefaultsStorageTests.swift
+++ b/Tests/ExperimentTests/UserDefaultsStorageTests.swift
@@ -30,7 +30,6 @@ class UserDefaultsStorageTests: XCTestCase {
         storage.load()
         let storageVariants = storage.getAll()
         XCTAssertEqual(variants, storageVariants)
-        
     }
     
     func testPutSaveAndGetAll() {

--- a/Tests/ExperimentTests/VariantTests.swift
+++ b/Tests/ExperimentTests/VariantTests.swift
@@ -1,0 +1,123 @@
+//
+//  VariantTests.swift
+//  ExperimentTests
+//
+//  Created by Brian Giori on 6/29/21.
+//
+
+import XCTest
+@testable import Experiment
+
+
+let encoder = JSONEncoder()
+let decoder = JSONDecoder()
+
+let payloadObjectJson = """
+{"testing":123}
+"""
+let payloadObject = try! JSONSerialization.jsonObject(with: payloadObjectJson.data(using: .utf8)!, options: [])
+
+let payloadArrayJson = """
+["testing","testing",123]
+"""
+let payloadArray = try! JSONSerialization.jsonObject(with: payloadArrayJson.data(using: .utf8)!, options: [])
+
+let variantNullPayload = Variant("testNull", payload: nil)
+let variantStringPayload = Variant("testString", payload: "test")
+let variantIntPayload = Variant("testInt", payload: 69)
+let variantDoublePayload = Variant("testDouble", payload: 6.9)
+let variantBoolPayload = Variant("testBool", payload: true)
+let variantObjectPayload = Variant("testObject", payload: payloadObject)
+let variantArrayPayload = Variant("testObject", payload: payloadArray)
+
+class VariantTests: XCTestCase {
+
+    func testVariantNullPayload() {
+        let original = variantNullPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        XCTAssertNil(decoded.payload)
+    }
+    
+    func testVariantStringPayload() {
+        let original = variantStringPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! String
+        let decodedPayload = decoded.payload as! String
+        XCTAssertEqual(decodedPayload, originalPayload)
+    }
+    
+    func testVariantIntPayload() {
+        let original = variantIntPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! Int
+        let decodedPayload = decoded.payload as! Int
+        XCTAssertEqual(decodedPayload, originalPayload)
+    }
+    
+    func testVariantDoublePayload() {
+        let original = variantDoublePayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! Double
+        let decodedPayload = decoded.payload as! Double
+        XCTAssertEqual(decodedPayload, originalPayload)
+    }
+    
+    func testVariantBoolPayload() {
+        let original = variantBoolPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! Bool
+        let decodedPayload = decoded.payload as! Bool
+        XCTAssertEqual(decodedPayload, originalPayload)
+    }
+    
+    func testVariantObjectPayload() {
+        let original = variantObjectPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! [String:Any]
+        let decodedPayload = decoded.payload as! [String:Any]
+        XCTAssertEqual(decodedPayload.debugDescription, originalPayload.debugDescription)
+    }
+    
+    func testVariantArrayPayload() {
+        let original = variantArrayPayload
+        print("-------------\noriginal: \(original)")
+        let encoded = try! encoder.encode(original)
+        print("encoded: \(String(data: encoded, encoding: .utf8)!)")
+        let decoded = try! decoder.decode(Variant.self, from: encoded)
+        print("decoded: \(decoded)")
+        XCTAssertEqual(decoded, original)
+        let originalPayload = original.payload as! [Any]
+        let decodedPayload = decoded.payload as! [Any]
+        XCTAssertEqual(decodedPayload.debugDescription, originalPayload.debugDescription)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Fixes an issue where variants where not properly being loaded from user defaults.
 * underlying cause is due to the codable implementation failing if the payload is nil

Added simple tests for variant encoding/decoding and storage functionality

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> yes
