### PR TITLE
feat: exposure tracking through analytics provider

### DIFF
--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */; };
+		207CBB9026AB8B9900A0029D /* ExperimentAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */; };
+		207CBB9426AB8BD400A0029D /* ExperimentAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */; };
+		207CBB9826AB8C9800A0029D /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB9726AB8C9800A0029D /* ExposureEvent.swift */; };
 		20B1BB8E2683CC2A003A960F /* Backoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BB8D2683CC2A003A960F /* Backoff.swift */; };
 		20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BF20268BBDA4003A960F /* VariantTests.swift */; };
 		20B1BF2B268BFFD7003A960F /* UserDefaultsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B1BF2A268BFFD7003A960F /* UserDefaultsStorageTests.swift */; };
@@ -38,6 +41,9 @@
 
 /* Begin PBXFileReference section */
 		201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentUserTests.swift; sourceTree = "<group>"; };
+		207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentAnalyticsProvider.swift; sourceTree = "<group>"; };
+		207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentAnalyticsEvent.swift; sourceTree = "<group>"; };
+		207CBB9726AB8C9800A0029D /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
 		20B1BB8D2683CC2A003A960F /* Backoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backoff.swift; sourceTree = "<group>"; };
 		20B1BF20268BBDA4003A960F /* VariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantTests.swift; sourceTree = "<group>"; };
 		20B1BF2A268BFFD7003A960F /* UserDefaultsStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorageTests.swift; sourceTree = "<group>"; };
@@ -122,6 +128,9 @@
 				E9030DB425B8AFC600BA1BA8 /* Variant.swift */,
 				E914961225796DA800C64B38 /* Experiment.h */,
 				E914961325796DA800C64B38 /* Info.plist */,
+				207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */,
+				207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */,
+				207CBB9726AB8C9800A0029D /* ExposureEvent.swift */,
 			);
 			path = Experiment;
 			sourceTree = "<group>";
@@ -271,9 +280,12 @@
 				E9C5D91F2579718E00867574 /* ExperimentUser.swift in Sources */,
 				E9C5D91C2579718E00867574 /* ExperimentClient.swift in Sources */,
 				E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */,
+				207CBB9026AB8B9900A0029D /* ExperimentAnalyticsProvider.swift in Sources */,
+				207CBB9426AB8BD400A0029D /* ExperimentAnalyticsEvent.swift in Sources */,
 				E9C5D91E2579718E00867574 /* ExperimentConfig.swift in Sources */,
 				E9C5D9202579718E00867574 /* Experiment.swift in Sources */,
 				E9C5D91D2579718E00867574 /* UserDefaultsStorage.swift in Sources */,
+				207CBB9826AB8C9800A0029D /* ExposureEvent.swift in Sources */,
 				E9C5D9222579718E00867574 /* Storage.swift in Sources */,
 				E9C5D9212579718E00867574 /* InMemoryStorage.swift in Sources */,
 				20B1BB8E2683CC2A003A960F /* Backoff.swift in Sources */,

--- a/Sources/Experiment/ExperimentAnalyticsEvent.swift
+++ b/Sources/Experiment/ExperimentAnalyticsEvent.swift
@@ -7,7 +7,17 @@
 
 import Foundation
 
+/// Analytics event for tracking events generated from the experiment SDK client.
+/// These events are sent to the implementation provided by an
+/// ``ExperimentAnalyticsProvider``.
 public protocol ExperimentAnalyticsEvent {
+    
+    /// The name of the event. Should be passed as the event tracking name to the
+    /// analytics implementation provided by the ``ExperimentAnalyticsProvider``.
     var name: String { get }
+    
+    /// Properties for the analytics event. Should be passed as the event
+    /// properties to the analytics implementation provided by the
+    /// ``ExperimentAnalyticsProvider``.
     var properties: [String: String?] { get }
 }

--- a/Sources/Experiment/ExperimentAnalyticsEvent.swift
+++ b/Sources/Experiment/ExperimentAnalyticsEvent.swift
@@ -1,0 +1,13 @@
+//
+//  ExperimentAnalyticsEvent.swift
+//  Experiment
+//
+//  Created by Brian Giori on 7/23/21.
+//
+
+import Foundation
+
+public protocol ExperimentAnalyticsEvent {
+    var name: String { get }
+    var properties: [String: String?] { get }
+}

--- a/Sources/Experiment/ExperimentAnalyticsProvider.swift
+++ b/Sources/Experiment/ExperimentAnalyticsProvider.swift
@@ -1,0 +1,12 @@
+//
+//  ExperimentAnalyticsProvider.swift
+//  Experiment
+//
+//  Created by Brian Giori on 7/23/21.
+//
+
+import Foundation
+
+public protocol ExperimentAnalyticsProvider {
+    func track(_ event: ExperimentAnalyticsEvent)
+}

--- a/Sources/Experiment/ExperimentAnalyticsProvider.swift
+++ b/Sources/Experiment/ExperimentAnalyticsProvider.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+/// Provides a analytics implementation for standard experiment events generated
+/// by the client (e.g. ``ExposureEvent``).
 public protocol ExperimentAnalyticsProvider {
+    
     func track(_ event: ExperimentAnalyticsEvent)
 }

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -21,6 +21,8 @@ public struct ExperimentConfig {
     public private(set) var serverUrl: String = ExperimentConfig.Defaults.serverUrl
     public private(set) var fetchTimeoutMillis: Int = ExperimentConfig.Defaults.fetchTimeoutMillis
     public private(set) var retryFetchOnFailure: Bool = ExperimentConfig.Defaults.retryFetchOnFailure
+    public private(set) var userProvider: ExperimentUserProvider? = ExperimentConfig.Defaults.userProvider
+    public private(set) var analyticsProvider: ExperimentAnalyticsProvider? = ExperimentConfig.Defaults.analyticsProvider
 
     public init() {
         // Default Config
@@ -34,6 +36,8 @@ public struct ExperimentConfig {
         static let serverUrl: String = "https://api.lab.amplitude.com"
         static let fetchTimeoutMillis: Int = 10000
         static let retryFetchOnFailure: Bool = true
+        static let userProvider: ExperimentUserProvider? = nil
+        static let analyticsProvider: ExperimentAnalyticsProvider? = nil
     }
     
     public class Builder {
@@ -76,6 +80,16 @@ public struct ExperimentConfig {
         
         public func fetchRetryOnFailure(_ fetchRetryOnFailure: Bool) -> Builder {
             config.retryFetchOnFailure = fetchRetryOnFailure
+            return self
+        }
+        
+        public func userProvider(_ userProvider: ExperimentUserProvider?) -> Builder {
+            config.userProvider = userProvider
+            return self
+        }
+        
+        public func analyticsProvider(_ analyticsProvider: ExperimentAnalyticsProvider?) -> Builder {
+            config.analyticsProvider = analyticsProvider
             return self
         }
 

--- a/Sources/Experiment/ExposureEvent.swift
+++ b/Sources/Experiment/ExposureEvent.swift
@@ -1,0 +1,28 @@
+//
+//  ExposureEvent.swift
+//  Experiment
+//
+//  Created by Brian Giori on 7/23/21.
+//
+
+import Foundation
+
+public class ExposureEvent : ExperimentAnalyticsEvent {
+    
+    public let name: String = "[Experiment] Exposure"
+    public let properties: [String: String?]
+    
+    public let user: ExperimentUser
+    public let key: String
+    public let variant: Variant
+    
+    public init(user: ExperimentUser, key: String, variant: Variant) {
+        self.user = user
+        self.key = key
+        self.variant = variant
+        self.properties = [
+            "key": key,
+            "variant": variant.value
+        ]
+    }
+}

--- a/Sources/Experiment/ExposureEvent.swift
+++ b/Sources/Experiment/ExposureEvent.swift
@@ -7,13 +7,20 @@
 
 import Foundation
 
+/// Event for tracking a user's exposure to a variant. This event will not count
+/// towards your analytics event volume.
 public class ExposureEvent : ExperimentAnalyticsEvent {
     
     public let name: String = "[Experiment] Exposure"
     public let properties: [String: String?]
     
+    /// The user exposed to the flag/experiment variant.
     public let user: ExperimentUser
+    
+    /// The key of the flag/experiment that the user has been exposed to.
     public let key: String
+    
+    /// The variant of the flag/experiment that the user has been exposed to.
     public let variant: Variant
     
     public init(user: ExperimentUser, key: String, variant: Variant) {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

* Deprecate `setUserProvider` & `getUserProvider`. Support user provider in config.
* Add analytics provider & event interface to config.
* Automatically track exposure events through analytics provider when `variant` is called. 

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
