### PR TITLE
fix: revert post to get with user in header

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -150,15 +150,15 @@ public class DefaultExperimentClient : ExperimentClient {
             completion(Result.failure(ExperimentError("json encode failed from dictionary: \(userDictionary)")))
             return nil
         }
-        if requestData.count > 8000 {
-            print("[Experiment] encoded user object length \(requestData.count) cannot be cached by CDN; must be < 8KB")
-        }
+        let userB64EncodedUrl = requestData.base64EncodedString().replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
         let url = URL(string: "\(self.config.serverUrl)/sdk/vardata")!
         var request = URLRequest(url: url)
-        request.httpMethod = "POST"
+        request.httpMethod = "GET"
         request.setValue("Api-Key \(self.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(userB64EncodedUrl, forHTTPHeaderField: "X-Amp-Exp-User")
         request.timeoutInterval = Double(timeoutMillis) / 1000.0
-        request.httpBody = requestData
         
         // Do fetch request
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
* Revert changing the fetch from POST to GET with the user info in a header

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
