### PR TITLE
feat: unset user properties when variant evaluates to null or is a fa…

### DIFF
--- a/Sources/Experiment/ExperimentAnalyticsEvent.swift
+++ b/Sources/Experiment/ExperimentAnalyticsEvent.swift
@@ -24,4 +24,20 @@ public protocol ExperimentAnalyticsEvent {
     
     /// User properties to identify with the user prior to sending the event.
     var userProperties: [String: Any?]? { get }
+
+
+    /// The user exposed to the flag/experiment variant.
+    var user: ExperimentUser { get };
+
+
+    /// The key of the flag/experiment that the user has been exposed to.
+    var key: String { get };
+
+
+    /// The variant of the flag/experiment that the user has been exposed to.
+    var variant: Variant { get };
+
+
+    /// The user property for the flag/experiment (auto-generated from the key)
+    var userProperty: String { get };
 }

--- a/Sources/Experiment/ExperimentAnalyticsProvider.swift
+++ b/Sources/Experiment/ExperimentAnalyticsProvider.swift
@@ -10,6 +10,21 @@ import Foundation
 /// Provides a analytics implementation for standard experiment events generated
 /// by the client (e.g. ``ExposureEvent``).
 public protocol ExperimentAnalyticsProvider {
-    
+
+    /// Wraps an analytics event track call. This is typically called by the
+    /// experiment client after setting user properties to track an
+    /// "[Experiment] Exposure" event
     func track(_ event: ExperimentAnalyticsEvent)
+
+
+    /// Wraps an analytics identify or set user property call. This is typically
+    /// called by the experiment client before sending an
+    /// "[Experiment] Exposure" event.
+    func setUserProperty(_ event: ExperimentAnalyticsEvent)
+
+
+    /// Wraps an analytics unset user property call. This is typically
+    /// called by the experiment client when a user has been evaluated to use
+    /// a fallback variant.
+    func unsetUserProperty(_ event: ExperimentAnalyticsEvent)
 }

--- a/Sources/Experiment/ExposureEvent.swift
+++ b/Sources/Experiment/ExposureEvent.swift
@@ -9,30 +9,27 @@ import Foundation
 
 /// Event for tracking a user's exposure to a variant. This event will not count
 /// towards your analytics event volume.
-public class ExposureEvent : ExperimentAnalyticsEvent {
-    
-    
+public class ExposureEvent : ExperimentAnalyticsEvent {    
     public let name: String = "[Experiment] Exposure"
     public let properties: [String: String?]
     public let userProperties: [String : Any?]?
 
-    /// The user exposed to the flag/experiment variant.
     public let user: ExperimentUser
-    
-    /// The key of the flag/experiment that the user has been exposed to.
     public let key: String
-    
-    /// The variant of the flag/experiment that the user has been exposed to.
     public let variant: Variant
+    public let userProperty: String
+
     
-    public init(user: ExperimentUser, key: String, variant: Variant) {
+    public init(user: ExperimentUser, key: String, variant: Variant, source: String) {
         self.user = user
         self.key = key
         self.variant = variant
         self.properties = [
             "key": key,
-            "variant": variant.value
+            "variant": variant.value,
+            "source": source
         ]
         self.userProperties = ["[Experiment] \(key)": variant.value]
+        self.userProperty = "[Experiment] \(key)"
     }
 }


### PR DESCRIPTION
…llback

<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

This adds the ability to unset user properties when a variant has no value or is a fallback.

Other changes:

- Fallback order changed for source = InitialVariants:
  1. InitialFlags
  2. Local Storage
  3. Function fallback
  4. Config fallback

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
