### PR TITLE
fix: potential crash with concurrent storage map copy and write

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -307,6 +307,8 @@ public class DefaultExperimentClient : ExperimentClient {
     private func sourceVariants() -> [String: Variant] {
         switch config.source {
         case .LocalStorage:
+            storageLock.wait()
+            defer { storageLock.signal() }
             return storage.getAll()
         case .InitialVariants:
             return config.initialVariants
@@ -318,6 +320,8 @@ public class DefaultExperimentClient : ExperimentClient {
         case .LocalStorage:
             return config.initialVariants
         case .InitialVariants:
+            storageLock.wait()
+            defer { storageLock.signal() }
             return storage.getAll()
         }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
`Storage.getAll()` copies the storage cache dictionary which is not thread safe with regards to writing to the map concurrently. 

This change synchronizes `getAll()` with the other storage access in `storeVariants()` 

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
