### PR TITLE
fix: dont overwrite stored user with empty user on fetch

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -50,8 +50,11 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         self.storage.load()
     }
 
+    // TODO: allow for user to be null / missing
     public func fetch(user: ExperimentUser, completion: ((ExperimentClient, Error?) -> Void)? = nil) -> Void {
-        self.user = user
+        if self.user == nil || user != ExperimentUser() {
+            self.user = user
+        }
         let fetchUser = self.mergeUserWithProvider()
         _ = fetchInternal(
             user: fetchUser,

--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -52,7 +52,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
 
     // TODO: allow for user to be null / missing
     public func fetch(user: ExperimentUser, completion: ((ExperimentClient, Error?) -> Void)? = nil) -> Void {
-        if self.user == nil || user != ExperimentUser() {
+        if user != ExperimentUser() {
             self.user = user
         }
         let fetchUser = self.mergeUserWithProvider()

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -302,6 +302,18 @@ class ExperimentClientTests: XCTestCase {
         _ = client.variant(KEY)
         XCTAssertTrue(analyticsProvider.didExposureGetTracked)
     }
+    
+    func testEmptyUserDoesNotOverwriteCurrentUser() {
+        let user = ExperimentUserBuilder()
+            .deviceId("device_id")
+            .userId(nil)
+            .version("version")
+            .build()
+        client.setUser(user)
+        client.fetch(user: ExperimentUser())
+        let storedUser = client.getUser()
+        XCTAssertEqual(storedUser, user)
+    }
 }
 
 class TestAnalyticsProvider : ExperimentAnalyticsProvider {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
The expected behavior of the experiment client when fetching variants for a user is that if the user passed into fetch is empty, the fetch will occur with the current user. 

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
