### PR TITLE
feat: allow for non-string user property values

### DIFF
--- a/Sources/Experiment/ExperimentUser.swift
+++ b/Sources/Experiment/ExperimentUser.swift
@@ -113,8 +113,8 @@ import Foundation
         }
         
         var userPropertiesAnyValueEqual = false
-        if let userPropertiesAnyValue = self.userPropertiesAnyValue {
-            userPropertiesAnyValueEqual = NSDictionary(dictionary: userPropertiesAnyValue).isEqual(to: other.userPropertiesAnyValue)
+        if let userPropertiesAnyValue = self.userPropertiesAnyValue, let otherUserPropertiesAnyValue = other.userPropertiesAnyValue {
+            userPropertiesAnyValueEqual = NSDictionary(dictionary: userPropertiesAnyValue).isEqual(to: otherUserPropertiesAnyValue)
         } else {
             userPropertiesAnyValueEqual = other.userPropertiesAnyValue == nil
         }

--- a/Sources/Experiment/ExperimentUser.swift
+++ b/Sources/Experiment/ExperimentUser.swift
@@ -244,19 +244,18 @@ import Foundation
         }
 
         public func userProperty(_ property: String, value: Any) -> Builder {
-            guard var userProperties = self.userProperties, var userPropertiesAnyValue = self.userPropertiesAnyValue else {
-                if let stringValue = value as? String {
-                    self.userProperties = [property: stringValue]
-                }
-                self.userPropertiesAnyValue = [property: value]
-                return self
-            }
             if let stringValue = value as? String {
-                userProperties[property] = stringValue
-                self.userProperties = userProperties
+                if self.userProperties == nil {
+                    self.userProperties = [property: stringValue]
+                } else {
+                    self.userProperties![property] = stringValue
+                }
             }
-            userPropertiesAnyValue[property] = value
-            self.userPropertiesAnyValue = userPropertiesAnyValue
+            if self.userPropertiesAnyValue == nil {
+                self.userPropertiesAnyValue = [property: value]
+            } else {
+                self.userPropertiesAnyValue![property] = value
+            }
             return self
         }
 

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -30,41 +30,51 @@ class ExperimentUserTests: XCTestCase {
         .version(nil)
         .country("country")
         .userProperties([
-            "user_id": "user_id",
-            "device_id": "device_id",
-            "country": "country",
-            "user_properties": [
-                "stringUserProperty": "value",
-                "intUserProperty": 100,
-                "doubleUserProperty": 3.14159,
-                "boolUserProperty": true,
-                "stringArrayUserProperty": ["zero", "one", "two", "three"],
-                "intArrayUserProperty": [0, 1, 2, 3],
-                "anyArrayUserProperty": [0, "one", true, 3.0]
-            ]
+            "stringUserProperty": "value",
+            "intUserProperty": 100,
+            "doubleUserProperty": 3.14159,
+            "boolUserProperty": true,
+            "stringArrayUserProperty": ["zero", "one", "two", "three"],
+            "intArrayUserProperty": [0, 1, 2, 3],
+            "anyArrayUserProperty": [0, "one", true, 3.0]
         ])
         .build()
     
-    func testExperimentUserJSONSerialization() {
-        
-        let expectedDictionary: [String : Any] = [
-            "user_id": "user_id",
-            "device_id": "device_id",
-            "country": "country",
-            "user_properties": [
-                "stringUserProperty": "value",
-                "intUserProperty": 100,
-                "doubleUserProperty": 3.14159,
-                "boolUserProperty": true,
-                "stringArrayUserProperty": ["zero", "one", "two", "three"],
-                "intArrayUserProperty": [0, 1, 2, 3],
-                "anyArrayUserProperty": [0, "one", true, 3.0]
-            ]
+    let expectedUserProperties: [String : Any] = [
+        "stringUserProperty": "value",
+        "intUserProperty": 100,
+        "doubleUserProperty": 3.14159,
+        "boolUserProperty": true,
+        "stringArrayUserProperty": ["zero", "one", "two", "three"],
+        "intArrayUserProperty": [0, 1, 2, 3],
+        "anyArrayUserProperty": [0, "one", true, 3.0]
+    ]
+    
+    let expectedUser: [String : Any] = [
+        "user_id": "user_id",
+        "device_id": "device_id",
+        "country": "country",
+        "user_properties": [
+            "stringUserProperty": "value",
+            "intUserProperty": 100,
+            "doubleUserProperty": 3.14159,
+            "boolUserProperty": true,
+            "stringArrayUserProperty": ["zero", "one", "two", "three"],
+            "intArrayUserProperty": [0, 1, 2, 3],
+            "anyArrayUserProperty": [0, "one", true, 3.0]
         ]
-
+    ]
+    
+    func testExperimentUserUserProperties() {
+        XCTAssertEqual(user, userBulkUserProperties)
+        XCTAssert(NSDictionary(dictionary: user.getUserProperties()!).isEqual(to: expectedUserProperties))
+        XCTAssert(NSDictionary(dictionary: userBulkUserProperties.getUserProperties()!).isEqual(to: expectedUserProperties))
+    }
+    
+    func testExperimentUserJSONSerialization() {
         let userData = try! JSONSerialization.data(withJSONObject: user.toDictionary(), options: [])
         let bulkUserData = try! JSONSerialization.data(withJSONObject: user.toDictionary(), options: [])
-        let expectedData = try! JSONSerialization.data(withJSONObject: expectedDictionary, options: [])
+        let expectedData = try! JSONSerialization.data(withJSONObject: expectedUser, options: [])
 
         let userAnyObject = try! JSONSerialization.jsonObject(with: userData, options: [])
         let bulkUserAnyObject = try! JSONSerialization.jsonObject(with: bulkUserData, options: [])
@@ -93,6 +103,8 @@ class ExperimentUserTests: XCTestCase {
         print(user)
         print(user2)
         XCTAssert(user != user2)
+        print(user)
+        print(user3)
         XCTAssert(user == user3)
     }
 

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -65,10 +65,18 @@ class ExperimentUserTests: XCTestCase {
         ]
     ]
     
-    func testExperimentUserUserProperties() {
+    func testUserPropertiesEquals() {
         XCTAssertEqual(user, userBulkUserProperties)
         XCTAssert(NSDictionary(dictionary: user.getUserProperties()!).isEqual(to: expectedUserProperties))
         XCTAssert(NSDictionary(dictionary: userBulkUserProperties.getUserProperties()!).isEqual(to: expectedUserProperties))
+    }
+    
+    func testSetNilEmptyUserPropertiesEquals() {
+        let newUser1 = user.copyToBuilder().userProperties(nil).build()
+        let newUser2 = userBulkUserProperties.copyToBuilder().userProperties(nil).build()
+        let otherUser = ExperimentUserBuilder().userId("user_id").deviceId("device_id").country("country").build()
+        XCTAssertEqual(newUser1, newUser2)
+        XCTAssertEqual(newUser1, otherUser)
     }
     
     func testExperimentUserJSONSerialization() {
@@ -100,11 +108,7 @@ class ExperimentUserTests: XCTestCase {
             .userProperty("userPropertyKey", value: "different value")
             .build()
         let user3 = user.copyToBuilder().build()
-        print(user)
-        print(user2)
         XCTAssert(user != user2)
-        print(user)
-        print(user3)
         XCTAssert(user == user3)
     }
 

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -15,7 +15,34 @@ class ExperimentUserTests: XCTestCase {
         .userId("user_id")
         .version(nil)
         .country("country")
-        .userProperty("userPropertyKey", value: "value")
+        .userProperty("stringUserProperty", value: "value")
+        .userProperty("intUserProperty", value: 100)
+        .userProperty("doubleUserProperty", value: 3.14159)
+        .userProperty("boolUserProperty", value: true)
+        .userProperty("stringArrayUserProperty", value: ["zero", "one", "two", "three"])
+        .userProperty("intArrayUserProperty", value: [0, 1, 2, 3])
+        .userProperty("anyArrayUserProperty", value: [0, "one", true, 3.0])
+        .build()
+    
+    let userBulkUserProperties = ExperimentUserBuilder()
+        .deviceId("device_id")
+        .userId("user_id")
+        .version(nil)
+        .country("country")
+        .userProperties([
+            "user_id": "user_id",
+            "device_id": "device_id",
+            "country": "country",
+            "user_properties": [
+                "stringUserProperty": "value",
+                "intUserProperty": 100,
+                "doubleUserProperty": 3.14159,
+                "boolUserProperty": true,
+                "stringArrayUserProperty": ["zero", "one", "two", "three"],
+                "intArrayUserProperty": [0, 1, 2, 3],
+                "anyArrayUserProperty": [0, "one", true, 3.0]
+            ]
+        ])
         .build()
     
     func testExperimentUserJSONSerialization() {
@@ -25,26 +52,37 @@ class ExperimentUserTests: XCTestCase {
             "device_id": "device_id",
             "country": "country",
             "user_properties": [
-                "userPropertyKey": "value"
+                "stringUserProperty": "value",
+                "intUserProperty": 100,
+                "doubleUserProperty": 3.14159,
+                "boolUserProperty": true,
+                "stringArrayUserProperty": ["zero", "one", "two", "three"],
+                "intArrayUserProperty": [0, 1, 2, 3],
+                "anyArrayUserProperty": [0, "one", true, 3.0]
             ]
         ]
 
         let userData = try! JSONSerialization.data(withJSONObject: user.toDictionary(), options: [])
+        let bulkUserData = try! JSONSerialization.data(withJSONObject: user.toDictionary(), options: [])
         let expectedData = try! JSONSerialization.data(withJSONObject: expectedDictionary, options: [])
 
         let userAnyObject = try! JSONSerialization.jsonObject(with: userData, options: [])
+        let bulkUserAnyObject = try! JSONSerialization.jsonObject(with: bulkUserData, options: [])
         let expectedAnyObject = try! JSONSerialization.jsonObject(with: expectedData, options: [])
 
         let userDict = userAnyObject as! [String:Any]
+        let bulkUserDict = bulkUserAnyObject as! [String:Any]
         let expectedDict = expectedAnyObject as! [String:Any]
 
-        let userUserDict = userDict["user_properties"] as! [String:String]
-        let expectedUserDict = userDict["user_properties"] as! [String:String]
-
+        let userUserDict = userDict["user_properties"] as! [String:Any]
+        let bulkUserUserDict = bulkUserDict["user_properties"] as! [String:Any]
+        let expectedUserDict = userDict["user_properties"] as! [String:Any]
+        
         XCTAssert(userDict["user_id"] as! String == expectedDict["user_id"] as! String)
         XCTAssert(userDict["device_id"] as! String == expectedDict["device_id"] as! String)
         XCTAssert(userDict["country"] as! String == expectedDict["country"] as! String)
-        XCTAssert(userUserDict == expectedUserDict)
+        XCTAssert(NSDictionary(dictionary: userUserDict).isEqual(to: expectedUserDict))
+        XCTAssert(NSDictionary(dictionary: bulkUserUserDict).isEqual(to: expectedUserDict))
     }
 
     func testExperimentUserEquality() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

add ability to add and query non-string user properties on the experiment user object in a backwards compatible manner.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
