### PR TITLE
fix: fix variant equality for object payloads

### DIFF
--- a/Sources/Experiment/Backoff.swift
+++ b/Sources/Experiment/Backoff.swift
@@ -17,7 +17,7 @@ internal class Backoff {
 
     // Dispatch
     private let lock = DispatchSemaphore(value: 1)
-    private let fetchQueue = DispatchQueue(label: "com.amplitude.experiment.fetch.backoff", qos: .background)
+    private let fetchQueue = DispatchQueue(label: "com.amplitude.experiment.fetch.backoff", qos: .default)
 
     // State
     private var started: Bool = false

--- a/Sources/Experiment/Variant.swift
+++ b/Sources/Experiment/Variant.swift
@@ -67,6 +67,9 @@ import Foundation
         guard self.payload != nil, other.payload != nil else {
             return false
         }
+        if let objectPayload = self.payload as? [String: Any], let otherObjectPayload = self.payload as? [String: Any] {
+            return NSDictionary(dictionary: objectPayload).isEqual(to: otherObjectPayload)
+        }
         let lhsData = try? JSONEncoder().encode(self)
         let rhsData = try? JSONEncoder().encode(other)
         return lhsData == rhsData

--- a/Tests/ExperimentTests/VariantTests.swift
+++ b/Tests/ExperimentTests/VariantTests.swift
@@ -13,7 +13,7 @@ let encoder = JSONEncoder()
 let decoder = JSONDecoder()
 
 let payloadObjectJson = """
-{"testing":123}
+{"testing":123,"repeat":[1,2,3],"ok":true}
 """
 let payloadObject = try! JSONSerialization.jsonObject(with: payloadObjectJson.data(using: .utf8)!, options: [])
 
@@ -105,7 +105,7 @@ class VariantTests: XCTestCase {
         XCTAssertEqual(decoded, original)
         let originalPayload = original.payload as! [String:Any]
         let decodedPayload = decoded.payload as! [String:Any]
-        XCTAssertEqual(decodedPayload.debugDescription, originalPayload.debugDescription)
+        XCTAssertEqual(NSDictionary(dictionary: originalPayload), NSDictionary(dictionary: decodedPayload))
     }
     
     func testVariantArrayPayload() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
