### PR TITLE
feat: invalidate exposure cache on user identity change

### DIFF
--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -8,11 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */; };
+		2047CE312809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2047CE302809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift */; };
 		2073275A278E42B0002BBD43 /* SessionAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20732759278E42B0002BBD43 /* SessionAnalyticsProvider.swift */; };
 		207C95FA27A9F0A4008EE143 /* AnalyticsConnector.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 207C95F927A9F0A4008EE143 /* AnalyticsConnector.xcframework */; };
 		207C96E627B71262008EE143 /* ExposureTrackingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207C96E527B71262008EE143 /* ExposureTrackingProvider.swift */; };
 		207C96EC27B71770008EE143 /* Exposure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207C96EB27B71770008EE143 /* Exposure.swift */; };
-		207C96F027B719F2008EE143 /* SessionExposureTrackingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207C96EF27B719F2008EE143 /* SessionExposureTrackingProvider.swift */; };
+		207C96F027B719F2008EE143 /* UserSessionExposureTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207C96EF27B719F2008EE143 /* UserSessionExposureTracker.swift */; };
 		207CBB9026AB8B9900A0029D /* ExperimentAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */; };
 		207CBB9426AB8BD400A0029D /* ExperimentAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */; };
 		207CBB9826AB8C9800A0029D /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207CBB9726AB8C9800A0029D /* ExposureEvent.swift */; };
@@ -50,11 +51,12 @@
 
 /* Begin PBXFileReference section */
 		201A78DE2643AB6100663DCB /* ExperimentUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentUserTests.swift; sourceTree = "<group>"; };
+		2047CE302809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionExposureTrackerTests.swift; sourceTree = "<group>"; };
 		20732759278E42B0002BBD43 /* SessionAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAnalyticsProvider.swift; sourceTree = "<group>"; };
 		207C95F927A9F0A4008EE143 /* AnalyticsConnector.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AnalyticsConnector.xcframework; path = Carthage/Build/AnalyticsConnector.xcframework; sourceTree = "<group>"; };
 		207C96E527B71262008EE143 /* ExposureTrackingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureTrackingProvider.swift; sourceTree = "<group>"; };
 		207C96EB27B71770008EE143 /* Exposure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposure.swift; sourceTree = "<group>"; };
-		207C96EF27B719F2008EE143 /* SessionExposureTrackingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExposureTrackingProvider.swift; sourceTree = "<group>"; };
+		207C96EF27B719F2008EE143 /* UserSessionExposureTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionExposureTracker.swift; sourceTree = "<group>"; };
 		207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentAnalyticsProvider.swift; sourceTree = "<group>"; };
 		207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentAnalyticsEvent.swift; sourceTree = "<group>"; };
 		207CBB9726AB8C9800A0029D /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
@@ -163,7 +165,7 @@
 				20732759278E42B0002BBD43 /* SessionAnalyticsProvider.swift */,
 				207C96E527B71262008EE143 /* ExposureTrackingProvider.swift */,
 				207C96EB27B71770008EE143 /* Exposure.swift */,
-				207C96EF27B719F2008EE143 /* SessionExposureTrackingProvider.swift */,
+				207C96EF27B719F2008EE143 /* UserSessionExposureTracker.swift */,
 			);
 			path = Experiment;
 			sourceTree = "<group>";
@@ -179,6 +181,7 @@
 				2093E39F26A7690D0036A930 /* ObjectiveCTest.m */,
 				2093E39E26A7690D0036A930 /* ExperimentTests-Bridging-Header.h */,
 				20C9FA43278791E400A4D530 /* ConnectorIntegrationTests.swift */,
+				2047CE302809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift */,
 			);
 			path = ExperimentTests;
 			sourceTree = "<group>";
@@ -314,7 +317,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				207C96E627B71262008EE143 /* ExposureTrackingProvider.swift in Sources */,
-				207C96F027B719F2008EE143 /* SessionExposureTrackingProvider.swift in Sources */,
+				207C96F027B719F2008EE143 /* UserSessionExposureTracker.swift in Sources */,
 				E9C5D9232579718E00867574 /* ExperimentUserProvider.swift in Sources */,
 				E9C5D91F2579718E00867574 /* ExperimentUser.swift in Sources */,
 				E9C5D91C2579718E00867574 /* ExperimentClient.swift in Sources */,
@@ -345,6 +348,7 @@
 				201A78DF2643AB6100663DCB /* ExperimentUserTests.swift in Sources */,
 				2093E3A026A7690D0036A930 /* ObjectiveCTest.m in Sources */,
 				E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */,
+				2047CE312809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift in Sources */,
 				20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Experiment/UserSessionExposureTracker.swift
+++ b/Sources/Experiment/UserSessionExposureTracker.swift
@@ -6,19 +6,26 @@
 //
 
 import Foundation
+import AnalyticsConnector
 
-internal class SessionExposureTrackingProvider : ExposureTrackingProvider {
+internal class UserSessionExposureTracker {
     
     private let exposureTrackingProvider: ExposureTrackingProvider
     private let lock = DispatchSemaphore(value: 1)
     private var tracked = [String: String?]()
+    private var identity = Identity()
     
     init(exposureTrackingProvider: ExposureTrackingProvider) {
         self.exposureTrackingProvider = exposureTrackingProvider
     }
     
-    func track(exposure: Exposure) {
+    func track(exposure: Exposure, user: ExperimentUser? = nil) {
         lock.wait()
+        let newIdentity = Identity(userId: user?.userId, deviceId: user?.deviceId)
+        if (!identityEquals(identity, newIdentity)) {
+            tracked = [:]
+        }
+        identity = newIdentity
         if (tracked.index(forKey: exposure.flagKey) != nil &&
                 tracked[exposure.flagKey] == exposure.variant) {
             lock.signal()
@@ -28,5 +35,9 @@ internal class SessionExposureTrackingProvider : ExposureTrackingProvider {
             lock.signal()
         }
         exposureTrackingProvider.track(exposure: exposure)
+    }
+    
+    private func identityEquals(_ id1: Identity, _ id2: Identity) -> Bool {
+        return id1.userId == id2.userId && id1.deviceId == id2.deviceId
     }
 }

--- a/Tests/ExperimentTests/ConnectorIntegrationTests.swift
+++ b/Tests/ExperimentTests/ConnectorIntegrationTests.swift
@@ -68,7 +68,7 @@ class ConnectorIntegrationTests : XCTestCase {
     
     func testTrackCalledOnceEachPerVariantForDifferentFlagKeys() {
         let eventBridge = TestEventBridge()
-        let connectorExposureTrackingProvider = SessionExposureTrackingProvider(exposureTrackingProvider: ConnectorExposureTrackingProvider(eventBridge: eventBridge))
+        let connectorExposureTrackingProvider = UserSessionExposureTracker(exposureTrackingProvider: ConnectorExposureTrackingProvider(eventBridge: eventBridge))
         
         // Track event with variant
         
@@ -103,7 +103,7 @@ class ConnectorIntegrationTests : XCTestCase {
     
     func testTrackCalledOncePerVariantForTheSameFlagKey() {
         let eventBridge = TestEventBridge()
-        let connectorExposureTrackingProvider = SessionExposureTrackingProvider(exposureTrackingProvider: ConnectorExposureTrackingProvider(eventBridge: eventBridge))
+        let connectorExposureTrackingProvider = UserSessionExposureTracker(exposureTrackingProvider: ConnectorExposureTrackingProvider(eventBridge: eventBridge))
         
         // Track event with variant
         

--- a/Tests/ExperimentTests/UserSessionExposureTrackerTests.swift
+++ b/Tests/ExperimentTests/UserSessionExposureTrackerTests.swift
@@ -1,0 +1,221 @@
+//
+//  UserSessionExposureTrackerTests.swift
+//  ExperimentTests
+//
+//  Created by Brian Giori on 4/15/22.
+//
+
+import Foundation
+@testable import Experiment
+import XCTest
+
+class TestExposureTrackingProvider: ExposureTrackingProvider {
+    
+    public var lastExposure: Exposure? = nil
+    public var trackCount = 0
+    
+    func track(exposure: Exposure) {
+        trackCount += 1
+        lastExposure = exposure
+    }
+}
+
+class UserSessionExposureTrackerTests : XCTestCase {
+    
+    func testTrackCalledOncePerFlag() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(1, provider.trackCount)
+        
+        let exposure2 = Exposure(flagKey: "flag2", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure2)
+        }
+        XCTAssertEqual(exposure2, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnSameFlagWithVariantChangeValueToNull() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        let exposure2 = Exposure(flagKey: "flag", variant: nil)
+        for _ in 0...10 {
+            tracker.track(exposure: exposure2)
+        }
+        
+        XCTAssertEqual(exposure2, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnSameFlagWithVariantChangeValueToDifferentValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        let exposure2 = Exposure(flagKey: "flag", variant: nil)
+        for _ in 0...10 {
+            tracker.track(exposure: exposure2)
+        }
+        
+        XCTAssertEqual(exposure2, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdChangeNullToValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnDeviceIdChangeNullToValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().deviceId("did").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdChangeValueToNull() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUser())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnDeviceIdChangeValueToNull() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().deviceId("did").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUser())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdChangeValueToDifferentValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid2").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnDeviceIdChangeValueToDifferentValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().deviceId("did").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().deviceId("did2").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdAndDeviceIdChangeNullToValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure)
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").deviceId("did").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdAndDeviceIdChangeValueToNull() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").deviceId("did").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUser())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+    
+    func testTrackCalledAgainOnUserIdAndDeviceIdChangeValueToDifferentValue() {
+        let provider = TestExposureTrackingProvider()
+        let tracker = UserSessionExposureTracker(exposureTrackingProvider: provider)
+        
+        let exposure = Exposure(flagKey: "flag", variant: "variant")
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid").deviceId("did").build())
+        }
+        for _ in 0...10 {
+            tracker.track(exposure: exposure, user: ExperimentUserBuilder().userId("uid2").deviceId("did2").build())
+        }
+        
+        XCTAssertEqual(exposure, provider.lastExposure)
+        XCTAssertEqual(2, provider.trackCount)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Invalidate the once-per-session-per-flag exposure cache when the user id or device Id changes.


### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
