### PR TITLE
fix: increase integration timeout to 10 seconds

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -73,7 +73,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         }
         fetchQueue.async {
             do {
-                let fetchUser = try self.mergeUserWithProviderOrWait(timeout: .seconds(1))
+                let fetchUser = try self.mergeUserWithProviderOrWait(timeout: .seconds(10))
                 _ = self.fetchInternal(
                     user: fetchUser,
                     timeoutMillis: self.config.fetchTimeoutMillis,


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

increase integration timeout to 10 seconds

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
