### PR TITLE
fix: properly compare ExperimentUser properties

### DIFF
--- a/Sources/Experiment/ExperimentUser.swift
+++ b/Sources/Experiment/ExperimentUser.swift
@@ -124,7 +124,7 @@ import Foundation
         if let userPropertiesAnyValue = self.userPropertiesAnyValue, let otherUserPropertiesAnyValue = other.userPropertiesAnyValue {
             userPropertiesAnyValueEqual = NSDictionary(dictionary: userPropertiesAnyValue).isEqual(to: otherUserPropertiesAnyValue)
         } else {
-            userPropertiesAnyValueEqual = other.userPropertiesAnyValue == nil
+            userPropertiesAnyValueEqual = userProperties == nil && other.userProperties == nil
         }
         
         return self.deviceId == other.deviceId &&

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -77,6 +77,15 @@ class ExperimentUserTests: XCTestCase {
         let otherUser = ExperimentUserBuilder().userId("user_id").deviceId("device_id").country("country").build()
         XCTAssertEqual(newUser1, newUser2)
         XCTAssertEqual(newUser1, otherUser)
+        XCTAssertEqual(otherUser, newUser1)
+    }
+
+    func testNonNilUserPropertiesAreNotEqualToEmpty() {
+        let defaultUser = ExperimentUser()
+        let customUser = ExperimentUserBuilder().userProperty("some", value: "foo").build()
+
+        XCTAssertNotEqual(defaultUser, customUser)
+        XCTAssertNotEqual(customUser, defaultUser)
     }
     
     func testExperimentUserJSONSerialization() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

It fixes a failing comparison of `userProperties` of `ExperimentUser`, when all other properties are equal. It was assumed that receiver instance always has `nil` value in `userProperties`.
The issue occurred when custom user properties were set on ExperimentUser passed to `fetch` function, in order to merge it with the data provided by AmplitudeAnalytics integration.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
