### PR TITLE
fix: fix the connector user provider when id is set prior to provider init

### DIFF
--- a/Sources/Experiment/ConnectorUserProvider.swift
+++ b/Sources/Experiment/ConnectorUserProvider.swift
@@ -28,6 +28,9 @@ internal class ConnectorUserProvider : ExperimentUserProvider {
             defer { self.identityLock.signal() }
             self.identity = copyId(updatedId)
         }
+        self.identityLock.wait()
+        defer { self.identityLock.signal() }
+        self.identity = self.identityStore.getIdentity()
     }
     
     

--- a/Tests/ExperimentTests/ConnectorIntegrationTests.swift
+++ b/Tests/ExperimentTests/ConnectorIntegrationTests.swift
@@ -33,6 +33,27 @@ class ConnectorIntegrationTests : XCTestCase {
         } while i < 10000
     }
     
+    func testUserIdUpdatePropogates() {
+        let instanceName = "integration_test_update"
+        let connector = AnalyticsConnector.getInstance(instanceName)
+        connector.identityStore.editIdentity()
+            .setUserId("user_id")
+            .setDeviceId("device_id")
+            .commit()
+        
+        let config = ExperimentConfigBuilder()
+            .instanceName(instanceName)
+            .build()
+        let client = Experiment.initializeWithAmplitudeAnalytics(apiKey: API_KEY, config: config) as! DefaultExperimentClient
+        let user = try! client.mergeUserWithProviderOrWait(timeout: .milliseconds(5000))
+        let expectedUser = ExperimentUserBuilder()
+            .userId("user_id")
+            .deviceId("device_id")
+            .build()
+        XCTAssertEqual(user.userId, expectedUser.userId)
+        XCTAssertEqual(user.deviceId, expectedUser.deviceId)
+    }
+    
     func testUserUpdatedOnUserIdentityChange() {
         let instanceName = "integration_test1"
         let connector = AnalyticsConnector.getInstance(instanceName)


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
