### PR TITLE
fix: call fetch on start by default

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -111,8 +111,6 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         startQueue.async {
             var error: Error? = nil
             let fetchOnStart = self.config.fetchOnStart?.boolValue ?? true
-            // We already have remote flags in our flag cache, so we know we need to
-            // evaluate remotely even before we've updated our flags.
             let startGroup = DispatchGroup()
             startGroup.enter()
             self.flagsInternal { e in

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -110,7 +110,7 @@ import Foundation
         static let fetchTimeoutMillis: Int = 10000
         static let retryFetchOnFailure: Bool = true
         static let automaticExposureTracking: Bool = true
-        static let fetchOnStart: NSNumber? = nil
+        static let fetchOnStart: NSNumber? = 1
         static let pollOnStart: Bool = true
         static let automaticFetchOnAmplitudeIdentityChange: Bool = false
         static let userProvider: ExperimentUserProvider? = nil

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -1079,7 +1079,7 @@ class ExperimentClientTests: XCTestCase {
         XCTAssertEqual("on", variant.value)
     }
     
-    func testStart_WithLocalEvaluationOnly_DoesNotCallFetch() {
+    func testStart_WithLocalEvaluationOnly_CallsFetch() {
         let storage = InMemoryStorage()
         let config = ExperimentConfigBuilder()
             .build()
@@ -1097,9 +1097,9 @@ class ExperimentClientTests: XCTestCase {
         let user = ExperimentUserBuilder()
             .build()
         client.startBlocking(user: user)
-        XCTAssertEqual(0, client.fetchCalls)
-        client.fetchBlocking(user: user)
         XCTAssertEqual(1, client.fetchCalls)
+        client.fetchBlocking(user: user)
+        XCTAssertEqual(2, client.fetchCalls)
     }
     
     func testStart_WithLocalEvalautionOnly_FetchOnStartEnabled_CallsFetch() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
call fetch on start by default

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
