### PR TITLE
fix: Adopt resource bundle for privacy manifest in Cocoapods

### DIFF
--- a/AmplitudeExperiment.podspec
+++ b/AmplitudeExperiment.podspec
@@ -14,19 +14,19 @@ Pod::Spec.new do |spec|
   
   spec.ios.deployment_target  = '10.0'
   spec.ios.source_files       = 'Sources/Experiment/**/*.{h,swift}'
-  spec.ios.resources          = 'Sources/Experiment/PrivacyInfo.xcprivacy'
+  spec.ios.resource_bundle    = { 'AmplitudeExperiment': ['Sources/Experiment/PrivacyInfo.xcprivacy'] }
 
   spec.osx.deployment_target  = '10.13'
   spec.osx.source_files       = 'sources/Experiment/**/*.{h,swift}'
-  spec.osx.resources          = 'Sources/Experiment/PrivacyInfo.xcprivacy'
+  spec.osx.resource_bundle    = { 'AmplitudeExperiment': ['Sources/Experiment/PrivacyInfo.xcprivacy'] }
 
   spec.tvos.deployment_target = '10.0'
   spec.tvos.source_files      = 'sources/Experiment/**/*.{h,swift}'
-  spec.tvos.resources         = 'Sources/Experiment/PrivacyInfo.xcprivacy'
+  spec.tvos.resource_bundle   = { 'AmplitudeExperiment': ['Sources/Experiment/PrivacyInfo.xcprivacy'] }
   
   spec.watchos.deployment_target = '3.0'
   spec.watchos.source_files      = 'sources/Experiment/**/*.{h,swift}'
-  spec.watchos.resources         = 'Sources/Experiment/PrivacyInfo.xcprivacy'
+  spec.watchos.resource_bundle   = { 'AmplitudeExperiment': ['Sources/Experiment/PrivacyInfo.xcprivacy'] }
   
   spec.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Prevents name conflicts for statically linked libraries in Cocoapods, see: https://guides.cocoapods.org/syntax/podspec.html#resource_bundles

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
