### PR TITLE
fix: toDictionary function should convert Date object to string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v2
 
-      - name: Set Xcode 14.2
+      - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.2.app
+          sudo xcode-select -switch /Applications/Xcode_15.1.app
 
       - name: Carthage Bootstrap
         run: carthage bootstrap --use-xcframeworks

--- a/Sources/Experiment/ExperimentUser.swift
+++ b/Sources/Experiment/ExperimentUser.swift
@@ -527,7 +527,6 @@ import Foundation
 
 internal extension ExperimentUser {
 
-    // Update the toDictionary method to handle NSDate objects
     func toDictionary() -> [String:Any] {
         var data = [String:Any]()
         data["device_id"] = self.deviceId

--- a/Sources/Experiment/ExperimentUser.swift
+++ b/Sources/Experiment/ExperimentUser.swift
@@ -526,7 +526,8 @@ import Foundation
 }
 
 internal extension ExperimentUser {
-    
+
+    // Update the toDictionary method to handle NSDate objects
     func toDictionary() -> [String:Any] {
         var data = [String:Any]()
         data["device_id"] = self.deviceId
@@ -543,9 +544,41 @@ internal extension ExperimentUser {
         data["device_model"] = self.deviceModel
         data["carrier"] = self.carrier
         data["library"] = self.library
-        data["user_properties"] = self.userPropertiesAnyValue
-        data["groups"] = self.groups
-        data["group_properties"] = self.groupProperties
+        
+        // Convert NSDate objects to ISO 8601 strings in user_properties
+        if let userProperties = self.userPropertiesAnyValue {
+            var convertedUserProperties = [String:Any]()
+            for (key, value) in userProperties {
+                if let dateValue = value as? Date {
+                    convertedUserProperties[key] = dateValue.iso8601
+                } else {
+                    convertedUserProperties[key] = value
+                }
+            }
+            data["user_properties"] = convertedUserProperties
+        }
+        
+        // Convert NSDate objects to ISO 8601 strings in group_properties
+        if let groupProperties = self.groupProperties {
+            var convertedGroupProperties = [String:Any]()
+            for (groupType, groups) in groupProperties {
+                var convertedGroups = [String:Any]()
+                for (groupName, properties) in groups {
+                    var convertedProperties = [String:Any]()
+                    for (key, value) in properties {
+                        if let dateValue = value as? Date {
+                            convertedProperties[key] = dateValue.iso8601
+                        } else {
+                            convertedProperties[key] = value
+                        }
+                    }
+                    convertedGroups[groupName] = convertedProperties
+                }
+                convertedGroupProperties[groupType] = convertedGroups
+            }
+            data["group_properties"] = convertedGroupProperties
+        }
+        
         return data
     }
     
@@ -612,4 +645,20 @@ extension ExperimentUser {
         }
         return context
     }
+}
+
+internal extension Date {
+    var iso8601: String {
+        return DateFormatter.iso8601.string(from: self)
+    }
+}
+
+internal extension DateFormatter {
+    static let iso8601: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -196,7 +196,6 @@ class ExperimentUserTests: XCTestCase {
         let userData = user.toDictionary()
         
         if let userProperties = userData["user_properties"] as? [String: Any] {
-            // Attempt to access the dateUserProperty
             if let dateUserProperty = userProperties["dateUserProperty"] as? String {
                 XCTAssertEqual(dateUserProperty, "2021-04-30T22:20:00.000Z")
             } else {

--- a/Tests/ExperimentTests/ExperimentUserTests.swift
+++ b/Tests/ExperimentTests/ExperimentUserTests.swift
@@ -181,4 +181,52 @@ class ExperimentUserTests: XCTestCase {
         let user = ExperimentUserBuilder().userProperty("test", value: "test").build()
         XCTAssertTrue(user != ExperimentUser())
     }
+    
+    func testUserPropertiesWithDateExtension() {
+        let date = Date(timeIntervalSince1970: 1619821200)
+        
+        let user = ExperimentUserBuilder()
+            .deviceId("device_id")
+            .userId("user_id")
+            .version(nil)
+            .country("country")
+            .userProperty("dateUserProperty", value: date)
+            .build()
+        
+        let userData = user.toDictionary()
+        
+        if let userProperties = userData["user_properties"] as? [String: Any] {
+            // Attempt to access the dateUserProperty
+            if let dateUserProperty = userProperties["dateUserProperty"] as? String {
+                XCTAssertEqual(dateUserProperty, "2021-04-30T22:20:00.000Z")
+            } else {
+                XCTFail("dateUserProperty not found or not a string")
+            }
+        } else {
+            XCTFail("user_properties not found or not a dictionary")
+        }
+    }
+
+    func testGroupPropertiesWithDateExtension() {
+        let date = Date(timeIntervalSince1970: 1619821200)
+        
+        let user = ExperimentUserBuilder()
+            .deviceId("device_id")
+            .userId("user_id")
+            .version(nil)
+            .country("country")
+            .groupProperty("groupType", "groupName", "dateGroupProperty", date.iso8601)
+            .build()
+        
+        let userData = user.toDictionary()
+        
+        if let groupProperties = userData["group_properties"] as? [String: Any],
+           let groupTypeDict = groupProperties["groupType"] as? [String: Any],
+           let groupNameDict = groupTypeDict["groupName"] as? [String: Any],
+           let dateGroupProperty = groupNameDict["dateGroupProperty"] as? String {
+            XCTAssertEqual(dateGroupProperty, "2021-04-30T22:20:00.000Z")
+        } else {
+            XCTFail("Unable to access group properties or dateGroupProperty")
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

fix: toDictionary function should convert Date object to string

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
