### PR TITLE
fix: Make `stop` method public

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -18,6 +18,7 @@ import Foundation
     @objc func setUser(_ user: ExperimentUser?)
     @objc func getUser() -> ExperimentUser?
     @objc func clear()
+    @objc func stop()
 
     @available(*, deprecated, message: "User ExperimentConfig.userProvider instead")
     @objc func getUserProvider() -> ExperimentUserProvider?


### PR DESCRIPTION
Summary

Exposes `stop()` method as part of the `ExperimentClient` protocol 

https://github.com/amplitude/experiment-ios-client/issues/58

