### PR TITLE
fix: ensure `completion` block is always called in `DefaultExperimentClient`

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -98,6 +98,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         runningLock.wait()
         if isRunning {
             runningLock.signal()
+            completion?(nil)
             return
         }
         isRunning = true


### PR DESCRIPTION
### Summary

This PR ensures that `DefaultExperimentClient.start` will always call the provided completion block.
This fixes an issue where wrapping the method for Swift Concurrency could result in a leaked continuation.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
