### PR TITLE
feat: increase flag polling interval; add flag poller interval config

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "amplitude/analytics-connector-ios" "v1.0.3"
+github "amplitude/analytics-connector-ios" "v1.3.0"

--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -31,6 +31,7 @@ private let fetchBackoffAttempts = 8
 private let fetchBackoffMinMillis = 500
 private let fetchBackoffMaxMillis = 10000
 private let fetchBackoffScalar: Float = 1.5
+private let minFlagConfigPollingIntervalMillis = 60000
 
 private let euServerUrl = "https://api.lab.eu.amplitude.com";
 private let euFlagsServerUrl = "https://flag.lab.eu.amplitude.com";
@@ -71,6 +72,9 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         let configBuilder = config.copyToBuilder()
         if config.serverUrl == ExperimentConfig.Defaults.serverUrl && config.flagsServerUrl == ExperimentConfig.Defaults.flagsServerUrl && config.serverZone == .EU {
             configBuilder.serverUrl(euServerUrl).flagsServerUrl(euFlagsServerUrl)
+        }
+        if config.flagConfigPollingIntervalMillis < minFlagConfigPollingIntervalMillis {
+            configBuilder.flagConfigPollingIntervalMillis(minFlagConfigPollingIntervalMillis)
         }
         self.config = configBuilder.build()
         if config.userProvider != nil {

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -33,6 +33,7 @@ import Foundation
     @objc public let automaticExposureTracking: Bool
     @objc public let fetchOnStart: NSNumber? // objc cant do nil boolean values, use nsnumber
     @objc public let pollOnStart: Bool
+    @objc public let flagConfigPollingIntervalMillis: Int
     @objc public let automaticFetchOnAmplitudeIdentityChange: Bool
     @objc public let userProvider: ExperimentUserProvider?
     @available(*, deprecated, message: "Use exposureTrackingProvider instead.")
@@ -54,6 +55,7 @@ import Foundation
         self.automaticExposureTracking = ExperimentConfig.Defaults.automaticExposureTracking
         self.fetchOnStart = ExperimentConfig.Defaults.fetchOnStart
         self.pollOnStart = ExperimentConfig.Defaults.pollOnStart
+        self.flagConfigPollingIntervalMillis = ExperimentConfig.Defaults.flagConfigPollingIntervalMillis
         self.automaticFetchOnAmplitudeIdentityChange = ExperimentConfig.Defaults.automaticFetchOnAmplitudeIdentityChange
         self.userProvider = ExperimentConfig.Defaults.userProvider
         self.analyticsProvider = ExperimentConfig.Defaults.analyticsProvider
@@ -75,6 +77,7 @@ import Foundation
         self.automaticExposureTracking = builder.automaticExposureTracking
         self.fetchOnStart = builder.fetchOnStart
         self.pollOnStart = builder.pollOnStart
+        self.flagConfigPollingIntervalMillis = builder.flagConfigPollingIntervalMillis
         self.automaticFetchOnAmplitudeIdentityChange = builder.automaticFetchOnAmplitudeIdentityChange
         self.userProvider = builder.userProvider
         self.analyticsProvider = builder.analyticsProvider
@@ -96,6 +99,7 @@ import Foundation
         self.automaticExposureTracking = builder.automaticExposureTracking
         self.fetchOnStart = builder.fetchOnStart
         self.pollOnStart = builder.pollOnStart
+        self.flagConfigPollingIntervalMillis = builder.flagConfigPollingIntervalMillis
         self.automaticFetchOnAmplitudeIdentityChange = builder.automaticFetchOnAmplitudeIdentityChange
         self.userProvider = builder.userProvider
         self.analyticsProvider = builder.analyticsProvider
@@ -117,6 +121,7 @@ import Foundation
         static let automaticExposureTracking: Bool = true
         static let fetchOnStart: NSNumber? = 1
         static let pollOnStart: Bool = true
+        static let flagConfigPollingIntervalMillis = 300000
         static let automaticFetchOnAmplitudeIdentityChange: Bool = false
         static let userProvider: ExperimentUserProvider? = nil
         static let analyticsProvider: ExperimentAnalyticsProvider? = nil
@@ -140,6 +145,7 @@ import Foundation
         internal var automaticExposureTracking: Bool = ExperimentConfig.Defaults.automaticExposureTracking
         internal var fetchOnStart: NSNumber? = ExperimentConfig.Defaults.fetchOnStart
         internal var pollOnStart: Bool = true
+        internal var flagConfigPollingIntervalMillis = ExperimentConfig.Defaults.flagConfigPollingIntervalMillis
         internal var automaticFetchOnAmplitudeIdentityChange: Bool = ExperimentConfig.Defaults.automaticFetchOnAmplitudeIdentityChange
         internal var userProvider: ExperimentUserProvider? = ExperimentConfig.Defaults.userProvider
         internal var analyticsProvider: ExperimentAnalyticsProvider? = ExperimentConfig.Defaults.analyticsProvider
@@ -239,6 +245,12 @@ import Foundation
         }
         
         @discardableResult
+        public func flagConfigPollingIntervalMillis(_ flagConfigPollingIntervalMillis: Int) -> Builder {
+            self.flagConfigPollingIntervalMillis = flagConfigPollingIntervalMillis
+            return self
+        }
+        
+        @discardableResult
         public func automaticFetchOnAmplitudeIdentityChange(_ automaticFetchOnAmplitudeIdentityChange: Bool) -> Builder {
             self.automaticFetchOnAmplitudeIdentityChange = automaticFetchOnAmplitudeIdentityChange
             return self
@@ -290,6 +302,7 @@ import Foundation
             .fetchRetryOnFailure(self.retryFetchOnFailure)
             .automaticExposureTracking(self.automaticExposureTracking)
             .pollOnStart(self.pollOnStart)
+            .flagConfigPollingIntervalMillis(self.flagConfigPollingIntervalMillis)
             .automaticFetchOnAmplitudeIdentityChange(self.automaticFetchOnAmplitudeIdentityChange)
             .userProvider(self.userProvider)
             .analyticsProvider(self.analyticsProvider)
@@ -317,6 +330,7 @@ import Foundation
     internal var automaticExposureTracking: Bool = ExperimentConfig.Defaults.automaticExposureTracking
     internal var fetchOnStart: NSNumber? = ExperimentConfig.Defaults.fetchOnStart
     internal var pollOnStart: Bool = true
+    internal var flagConfigPollingIntervalMillis: Int = ExperimentConfig.Defaults.flagConfigPollingIntervalMillis
     internal var automaticFetchOnAmplitudeIdentityChange: Bool = ExperimentConfig.Defaults.automaticFetchOnAmplitudeIdentityChange
     internal var userProvider: ExperimentUserProvider? = ExperimentConfig.Defaults.userProvider
     internal var analyticsProvider: ExperimentAnalyticsProvider? = ExperimentConfig.Defaults.analyticsProvider
@@ -407,6 +421,12 @@ import Foundation
     @discardableResult
     @objc public func pollOnStart(_ pollOnStart: Bool) -> ExperimentConfigBuilder {
         self.pollOnStart = pollOnStart
+        return self
+    }
+    
+    @discardableResult
+    @objc public func flagConfigPollingIntervalMillis(_ flagConfigPollingIntervalMillis: Int) -> ExperimentConfigBuilder {
+        self.flagConfigPollingIntervalMillis = flagConfigPollingIntervalMillis
         return self
     }
     

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -1229,6 +1229,24 @@ class ExperimentClientTests: XCTestCase {
             XCTAssertEqual(retryCalled, client.startRetriesCalls)
         }
     }
+    
+    func testFlagConfigPollingIntervalConfigNotSet() {
+        let config = ExperimentConfigBuilder().build()
+        let client = DefaultExperimentClient(apiKey: "", config: config, storage: InMemoryStorage())
+        XCTAssertEqual(300000, client.config.flagConfigPollingIntervalMillis)
+    }
+    
+    func testFlagConfigPollingIntervalConfigSetUnderMinimum() {
+        let config = ExperimentConfigBuilder().flagConfigPollingIntervalMillis(1000).build()
+        let client = DefaultExperimentClient(apiKey: "", config: config, storage: InMemoryStorage())
+        XCTAssertEqual(60000, client.config.flagConfigPollingIntervalMillis)
+    }
+    
+    func testFlagConfigPollingIntervalConfigSetOverMinimum() {
+        let config = ExperimentConfigBuilder().flagConfigPollingIntervalMillis(900000).build()
+        let client = DefaultExperimentClient(apiKey: "", config: config, storage: InMemoryStorage())
+        XCTAssertEqual(900000, client.config.flagConfigPollingIntervalMillis)
+    }
 }
 
 class TestAnalyticsProvider : ExperimentAnalyticsProvider {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

* Set the default flag polling interval to 5 min
* Add polling interval config with min value of 1 min

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
