### PR TITLE
fix: fix variant experiment key serialization w/ both keys set

### DIFF
--- a/Sources/Experiment/Variant.swift
+++ b/Sources/Experiment/Variant.swift
@@ -88,18 +88,13 @@ import Foundation
         let expKey = try? values.decode(String.self, forKey: .expKey)
         let metadataAny = try? values.decode([String: AnyDecodable].self, forKey: .metadata)
         var metadata = metadataAny?.filter { element in element.value.value != nil }.mapValues { anyDecodable in anyDecodable.value! }
-        let metadataExpKey = metadata?["experimentKey"] as? String
-        if let expKey = expKey, metadataExpKey == nil {
-            if metadata == nil {
-                metadata = ["experimentKey": expKey]
-            } else if metadata?["experimentKey"] != nil {
+        self.expKey = expKey ?? metadata?["experimentKey"] as? String
+        if let expKey = self.expKey {
+            if metadata != nil {
                 metadata?["experimentKey"] = expKey
+            } else {
+                metadata = ["experimentKey": expKey]
             }
-            self.expKey = expKey
-        } else if let metadataExpKey = metadataExpKey, expKey == nil {
-            self.expKey = metadataExpKey
-        } else {
-            self.expKey = nil
         }
         self.metadata = metadata
     }

--- a/Tests/ExperimentTests/VariantTests.swift
+++ b/Tests/ExperimentTests/VariantTests.swift
@@ -192,4 +192,12 @@ class VariantTests: XCTestCase {
         let variant = try! JSONDecoder().decode(Variant.self, from: rawVariant)
         XCTAssertEqual(Variant(key: "treatment", value: "on", expKey: "exp-1", metadata: ["experimentKey":"exp-1"]), variant)
     }
+    
+    func testV2VariantTransformationWithBothExperimentKeys() {
+        let rawVariant = """
+            {"key":"treatment", "value":"on", "expKey":"exp-1", "metadata":{"experimentKey":"exp-1"}}
+        """.data(using: .utf8)!
+        let variant = try! JSONDecoder().decode(Variant.self, from: rawVariant)
+        XCTAssertEqual(Variant(key: "treatment", value: "on", expKey: "exp-1", metadata: ["experimentKey":"exp-1"]), variant)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Fix but where expKey was not being properly set when the JSON object was parsed if both the expKey and metadata experiment key were already set in the raw form.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
