### PR TITLE
feat: add core dependency and plugin

### DIFF
--- a/AmplitudeExperiment.podspec
+++ b/AmplitudeExperiment.podspec
@@ -35,5 +35,6 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   spec.dependency 'AnalyticsConnector', '~> 1.3'
+  spec.dependency 'AmplitudeCore', '>=1.0.10', '<2.0.0'
 
 end

--- a/AmplitudeExperiment.podspec
+++ b/AmplitudeExperiment.podspec
@@ -35,6 +35,6 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   spec.dependency 'AnalyticsConnector', '~> 1.3'
-  spec.dependency 'AmplitudeCore', '>=1.0.10', '<2.0.0'
+  spec.dependency 'AmplitudeCore', '>=1.0.11', '<2.0.0'
 
 end

--- a/AmplitudeExperiment.podspec
+++ b/AmplitudeExperiment.podspec
@@ -35,6 +35,6 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   spec.dependency 'AnalyticsConnector', '~> 1.3'
-  spec.dependency 'AmplitudeCore', '>=1.0.11', '<2.0.0'
+  spec.dependency 'AmplitudeCore', '>=1.0.12', '<2.0.0'
 
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.3.1 
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.10

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "amplitude/analytics-connector-ios" ~> 1.3.1 
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.10
+github "amplitude/analytics-connector-ios" ~> 1.0 
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.11

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.0 
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.11
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.12

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "amplitude/analytics-connector-ios" "v1.3.0"
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" "1.0.10"
+github "amplitude/analytics-connector-ios" "v1.3.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" "1.0.10"
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" "1.0.11"
 github "amplitude/analytics-connector-ios" "v1.3.1"

--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -41,8 +41,8 @@
 		20F8C8DF2AB14B7100B5717C /* SelectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8C8DE2AB14B7100B5717C /* SelectableTests.swift */; };
 		20F8C8E12AB218C600B5717C /* TopologicalSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8C8E02AB218C600B5717C /* TopologicalSortTests.swift */; };
 		3E0148342921C08D004D259D /* FetchOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0148332921C08D004D259D /* FetchOptions.swift */; };
-		4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */; };
 		4E22BCAC2DCE99B70069239F /* ExperimentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */; };
+		4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */; };
 		4EDAAFB22DB060A700C90724 /* ExperimentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
@@ -720,7 +720,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.10;
+				minimumVersion = 1.0.12;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		20F8C8DF2AB14B7100B5717C /* SelectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8C8DE2AB14B7100B5717C /* SelectableTests.swift */; };
 		20F8C8E12AB218C600B5717C /* TopologicalSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8C8E02AB218C600B5717C /* TopologicalSortTests.swift */; };
 		3E0148342921C08D004D259D /* FetchOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0148332921C08D004D259D /* FetchOptions.swift */; };
+		4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */; };
+		4EDAAFB22DB060A700C90724 /* ExperimentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
 		E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E914961D25796DA800C64B38 /* ExperimentClientTests.swift */; };
@@ -103,6 +105,7 @@
 		20F8C8DE2AB14B7100B5717C /* SelectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableTests.swift; sourceTree = "<group>"; };
 		20F8C8E02AB218C600B5717C /* TopologicalSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopologicalSortTests.swift; sourceTree = "<group>"; };
 		3E0148332921C08D004D259D /* FetchOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchOptions.swift; sourceTree = "<group>"; };
+		4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPlugin.swift; sourceTree = "<group>"; };
 		E9030DB425B8AFC600BA1BA8 /* Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variant.swift; sourceTree = "<group>"; };
 		E914960F25796DA800C64B38 /* Experiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Experiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E914961225796DA800C64B38 /* Experiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Experiment.h; sourceTree = "<group>"; };
@@ -125,6 +128,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */,
 				207C95FA27A9F0A4008EE143 /* AnalyticsConnector.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,6 +178,7 @@
 		E914961125796DA800C64B38 /* Experiment */ = {
 			isa = PBXGroup;
 			children = (
+				4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */,
 				201FCB5F2BBB879500F07EC1 /* PrivacyInfo.xcprivacy */,
 				20F8C8C32AAFE2A100B5717C /* Murmur3.swift */,
 				20F8C8C62AAFE2B300B5717C /* SemanticVersion.swift */,
@@ -276,6 +281,7 @@
 			);
 			name = Experiment;
 			packageProductDependencies = (
+				4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */,
 			);
 			productName = Experiment;
 			productReference = E914960F25796DA800C64B38 /* Experiment.framework */;
@@ -328,6 +334,7 @@
 			);
 			mainGroup = E914960525796DA800C64B38;
 			packageReferences = (
+				4EDAAFAE2DB0609A00C90724 /* XCRemoteSwiftPackageReference "AmplitudeCore-Swift" */,
 			);
 			productRefGroup = E914961025796DA800C64B38 /* Products */;
 			projectDirPath = "";
@@ -377,6 +384,7 @@
 				207CBB9426AB8BD400A0029D /* ExperimentAnalyticsEvent.swift in Sources */,
 				20F8C8CA2AAFE2BF00B5717C /* TopologicalSort.swift in Sources */,
 				E9C5D91E2579718E00867574 /* ExperimentConfig.swift in Sources */,
+				4EDAAFB22DB060A700C90724 /* ExperimentPlugin.swift in Sources */,
 				20C9FA382787621100A4D530 /* ConnectorExposureTrackingProvider.swift in Sources */,
 				E9C5D9202579718E00867574 /* Experiment.swift in Sources */,
 				2073275A278E42B0002BBD43 /* SessionAnalyticsProvider.swift in Sources */,
@@ -701,6 +709,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		4EDAAFAE2DB0609A00C90724 /* XCRemoteSwiftPackageReference "AmplitudeCore-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.10;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4EDAAFAE2DB0609A00C90724 /* XCRemoteSwiftPackageReference "AmplitudeCore-Swift" */;
+			productName = AmplitudeCoreFramework;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E914960625796DA800C64B38 /* Project object */;
 }

--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		20F8C8E12AB218C600B5717C /* TopologicalSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8C8E02AB218C600B5717C /* TopologicalSortTests.swift */; };
 		3E0148342921C08D004D259D /* FetchOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0148332921C08D004D259D /* FetchOptions.swift */; };
 		4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */; };
+		4E22BCAC2DCE99B70069239F /* ExperimentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */; };
 		4EDAAFB22DB060A700C90724 /* ExperimentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
@@ -105,6 +106,7 @@
 		20F8C8DE2AB14B7100B5717C /* SelectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableTests.swift; sourceTree = "<group>"; };
 		20F8C8E02AB218C600B5717C /* TopologicalSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopologicalSortTests.swift; sourceTree = "<group>"; };
 		3E0148332921C08D004D259D /* FetchOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchOptions.swift; sourceTree = "<group>"; };
+		4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPluginTests.swift; sourceTree = "<group>"; };
 		4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPlugin.swift; sourceTree = "<group>"; };
 		E9030DB425B8AFC600BA1BA8 /* Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variant.swift; sourceTree = "<group>"; };
 		E914960F25796DA800C64B38 /* Experiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Experiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -215,6 +217,7 @@
 		E914961C25796DA800C64B38 /* ExperimentTests */ = {
 			isa = PBXGroup;
 			children = (
+				4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */,
 				20F8C8D62AAFF9DA00B5717C /* Murmur3Tests.swift */,
 				20F8C8D82AB0D33600B5717C /* EnglishWords.swift */,
 				20F8C8DA2AB0D36400B5717C /* HashX8632.swift */,
@@ -412,6 +415,7 @@
 				20F8C8E12AB218C600B5717C /* TopologicalSortTests.swift in Sources */,
 				20F8C8D92AB0D33600B5717C /* EnglishWords.swift in Sources */,
 				2093E3A026A7690D0036A930 /* ObjectiveCTest.m in Sources */,
+				4E22BCAC2DCE99B70069239F /* ExperimentPluginTests.swift in Sources */,
 				E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */,
 				2047CE312809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift in Sources */,
 				20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.11"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.12"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1")
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,7 +28,8 @@ let package = Package(
         .target(
             name: "Experiment",
             dependencies: [
-                .product(name: "AnalyticsConnector", package: "analytics-connector-ios")
+                .product(name: "AnalyticsConnector", package: "analytics-connector-ios"),
+                .product(name: "AmplitudeCoreFramework", package: "AmplitudeCore-Swift"),
             ],
             path: "Sources/Experiment",
             exclude: ["Info.plist"],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.11"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.11"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1")
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -28,7 +29,8 @@ let package = Package(
         .target(
             name: "Experiment",
             dependencies: [
-                .product(name: "AnalyticsConnector", package: "analytics-connector-ios")
+                .product(name: "AnalyticsConnector", package: "analytics-connector-ios"),
+                .product(name: "AmplitudeCoreFramework", package: "AmplitudeCore-Swift"),
             ],
             path: "Sources/Experiment",
             exclude: ["Info.plist"],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.11"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.12"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -38,7 +38,7 @@ private let euFlagsServerUrl = "https://flag.lab.eu.amplitude.com";
 
 internal class DefaultExperimentClient : NSObject, ExperimentClient {
 
-    private let apiKey: String
+    let apiKey: String
     
     internal let variants: LoadStoreCache<Variant>
     private let variantsStorageQueue = DispatchQueue(label: "com.amplitude.experiment.VariantsStorageQueue", attributes: .concurrent)

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -106,26 +106,26 @@ import Foundation
         self.exposureTrackingProvider = builder.exposureTrackingProvider
     }
 
-    internal struct Defaults {
-        static let debug: Bool = false
-        static let instanceName: String = "$default_instance"
-        static let fallbackVariant: Variant = Variant()
-        static let initialFlags: String? = nil
-        static let initialVariants: [String: Variant] = [:]
-        static let source: Source = Source.LocalStorage
-        static let serverUrl: String = "https://api.lab.amplitude.com"
-        static let flagsServerUrl: String = "https://flag.lab.amplitude.com"
-        static let serverZone: ServerZone = .US
-        static let fetchTimeoutMillis: Int = 10000
-        static let retryFetchOnFailure: Bool = true
-        static let automaticExposureTracking: Bool = true
-        static let fetchOnStart: NSNumber? = 1
-        static let pollOnStart: Bool = true
-        static let flagConfigPollingIntervalMillis = 300000
-        static let automaticFetchOnAmplitudeIdentityChange: Bool = false
-        static let userProvider: ExperimentUserProvider? = nil
-        static let analyticsProvider: ExperimentAnalyticsProvider? = nil
-        static let exposureTrackingProvider: ExposureTrackingProvider? = nil
+    public struct Defaults {
+        public static let debug: Bool = false
+        public static let instanceName: String = "$default_instance"
+        public static let fallbackVariant: Variant = Variant()
+        public static let initialFlags: String? = nil
+        public static let initialVariants: [String: Variant] = [:]
+        public static let source: Source = Source.LocalStorage
+        public static let serverUrl: String = "https://api.lab.amplitude.com"
+        public static let flagsServerUrl: String = "https://flag.lab.amplitude.com"
+        public static let serverZone: ServerZone = .US
+        public static let fetchTimeoutMillis: Int = 10000
+        public static let retryFetchOnFailure: Bool = true
+        public static let automaticExposureTracking: Bool = true
+        public static let fetchOnStart: NSNumber? = 1
+        public static let pollOnStart: Bool = true
+        public static let flagConfigPollingIntervalMillis = 300000
+        public static let automaticFetchOnAmplitudeIdentityChange: Bool = false
+        public static let userProvider: ExperimentUserProvider? = nil
+        public static let analyticsProvider: ExperimentAnalyticsProvider? = nil
+        public static let exposureTrackingProvider: ExposureTrackingProvider? = nil
     }
     
     @available(*, deprecated, message: "Use ExperimentConfigBuilder instead")

--- a/Sources/Experiment/ExperimentPlugin.swift
+++ b/Sources/Experiment/ExperimentPlugin.swift
@@ -1,0 +1,181 @@
+//
+//  Excperiment.swift
+//  experiment-ios-client
+//
+//  Created by Chris Leonavicius on 3/18/25.
+//
+
+import AmplitudeCore
+import Foundation
+
+@objc
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public class ExperimentPlugin: NSObject, UniversalPlugin {
+
+    @objcMembers
+    public class Config : NSObject {
+
+        public let deploymentKey: String?
+        public let debug: Bool
+        public let fallbackVariant: Variant
+        public let initialFlags: String?
+        public let initialVariants: [String: Variant]
+        public let source: Source
+        public let serverUrl: String
+        public let flagsServerUrl: String
+        public let fetchTimeoutMillis: Int
+        public let retryFetchOnFailure: Bool
+        public let automaticExposureTracking: Bool
+        public let fetchOnStart: NSNumber? // objc cant do nil boolean values, use nsnumber
+        public let pollOnStart: Bool
+        public let flagConfigPollingIntervalMillis: Int
+        public let automaticFetchOnAmplitudeIdentityChange: Bool
+
+        public init(deploymentKey: String? = nil,
+                    debug: Bool = ExperimentConfig.Defaults.debug,
+                    fallbackVariant: Variant = ExperimentConfig.Defaults.fallbackVariant,
+                    initialFlags: String? = ExperimentConfig.Defaults.initialFlags,
+                    initialVariants: [String : Variant] = ExperimentConfig.Defaults.initialVariants,
+                    source: Source = ExperimentConfig.Defaults.source,
+                    serverUrl: String = ExperimentConfig.Defaults.serverUrl,
+                    flagsServerUrl: String = ExperimentConfig.Defaults.flagsServerUrl,
+                    fetchTimeoutMillis: Int = ExperimentConfig.Defaults.fetchTimeoutMillis,
+                    retryFetchOnFailure: Bool = ExperimentConfig.Defaults.retryFetchOnFailure,
+                    automaticExposureTracking: Bool = ExperimentConfig.Defaults.automaticExposureTracking,
+                    fetchOnStart: NSNumber? = ExperimentConfig.Defaults.fetchOnStart,
+                    pollOnStart: Bool = ExperimentConfig.Defaults.pollOnStart,
+                    flagConfigPollingIntervalMillis: Int = ExperimentConfig.Defaults.flagConfigPollingIntervalMillis,
+                    automaticFetchOnAmplitudeIdentityChange: Bool = ExperimentConfig.Defaults.automaticFetchOnAmplitudeIdentityChange) {
+            self.deploymentKey = deploymentKey
+            self.debug = debug
+            self.fallbackVariant = fallbackVariant
+            self.initialFlags = initialFlags
+            self.initialVariants = initialVariants
+            self.source = source
+            self.serverUrl = serverUrl
+            self.flagsServerUrl = flagsServerUrl
+            self.fetchTimeoutMillis = fetchTimeoutMillis
+            self.retryFetchOnFailure = retryFetchOnFailure
+            self.automaticExposureTracking = automaticExposureTracking
+            self.fetchOnStart = fetchOnStart
+            self.pollOnStart = pollOnStart
+            self.flagConfigPollingIntervalMillis = flagConfigPollingIntervalMillis
+            self.automaticFetchOnAmplitudeIdentityChange = automaticFetchOnAmplitudeIdentityChange
+        }
+    }
+
+    static let pluginName: String = "com.amplitude.experiment"
+
+    @objc public var experiment: ExperimentClient?
+
+    private let config: Config
+    private var analytics: (any AnalyticsClient)?
+    private var logger: CoreLogger?
+
+    public var name: String? {
+        return Self.pluginName
+    }
+
+    @objc public init(config: Config = .init()) {
+        self.config = config
+    }
+
+    public func setup(analyticsClient: any AmplitudeCore.AnalyticsClient,
+                      amplitudeContext: AmplitudeCore.AmplitudeContext) {
+        self.analytics = analyticsClient
+
+        let configBuilder = ExperimentConfigBuilder()
+        configBuilder.debug = config.debug
+        configBuilder.instanceName = amplitudeContext.instanceName
+        configBuilder.fallbackVariant = config.fallbackVariant
+        configBuilder.initialFlags = config.initialFlags
+        configBuilder.initialVariants = config.initialVariants
+        configBuilder.source = config.source
+        configBuilder.serverUrl = config.serverUrl
+        configBuilder.flagsServerUrl = config.flagsServerUrl
+        let serverZone: ServerZone
+        switch amplitudeContext.serverZone {
+        case .US:
+            serverZone = .US
+        case .EU:
+            serverZone = .EU
+        @unknown default:
+            serverZone = .US
+        }
+        configBuilder.serverZone = serverZone
+        configBuilder.fetchTimeoutMillis = config.fetchTimeoutMillis
+        configBuilder.retryFetchOnFailure = config.retryFetchOnFailure
+        configBuilder.automaticExposureTracking = config.automaticExposureTracking
+        configBuilder.fetchOnStart = config.fetchOnStart
+        configBuilder.pollOnStart = config.pollOnStart
+        configBuilder.flagConfigPollingIntervalMillis = config.flagConfigPollingIntervalMillis
+        configBuilder.automaticFetchOnAmplitudeIdentityChange = config.automaticFetchOnAmplitudeIdentityChange
+        configBuilder.userProvider = self
+        configBuilder.exposureTrackingProvider = self
+
+        experiment = Experiment.initialize(apiKey: config.deploymentKey ?? amplitudeContext.apiKey,
+                                           config: configBuilder.build())
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension ExperimentPlugin: ExperimentUserProvider {
+
+    public func getUser() -> ExperimentUser {
+        let userBuilder = ExperimentUserBuilder()
+
+        if let analytics {
+            let identity = analytics.identity
+            userBuilder.deviceId = identity.deviceId
+            userBuilder.userId = identity.userId
+            userBuilder.userPropertiesAnyValue = identity.userProperties
+        }
+
+        return userBuilder.build()
+
+
+/*
+ TODO: add support for additional properties:
+        internal var version: String?
+        internal var country: String?
+        internal var region: String?
+        internal var dma: String?
+        internal var city: String?
+        internal var language: String?
+        internal var platform: String?
+        internal var os: String?
+        internal var deviceManufacturer: String?
+        internal var deviceModel: String?
+        internal var carrier: String?
+        internal var library: String?
+        internal var groups: [String: [String]]?
+        internal var groupProperties: [String: [String: [String: Any]]]?
+ */
+
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension ExperimentPlugin: ExposureTrackingProvider {
+
+    public func track(exposure: Exposure) {
+        guard let analytics else {
+            logger?.error(message: "Attempted to send exposure event from disconnected plugin")
+            return
+        }
+        var eventProperties = [String: Any]()
+        eventProperties["flag_key"] = exposure.flagKey
+        eventProperties["variant"] = exposure.variant
+        eventProperties["experiment_key"] = exposure.experimentKey
+        eventProperties["metadata"] = exposure.metadata
+        analytics.track(eventType: "$exposure", eventProperties: eventProperties)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension PluginHost {
+
+    public var experiment: ExperimentClient? {
+        return (plugin(name: ExperimentPlugin.pluginName) as? ExperimentPlugin)?.experiment
+    }
+}

--- a/Tests/ExperimentTests/ExperimentPluginTests.swift
+++ b/Tests/ExperimentTests/ExperimentPluginTests.swift
@@ -1,0 +1,215 @@
+//
+//  ExperimentPluginTests.swift
+//  Experiment
+//
+//  Created by Chris Leonavicius on 5/9/25.
+//
+
+import AmplitudeCore
+@testable import Experiment
+import XCTest
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+class ExperimentPluginTests: XCTestCase {
+
+    let apiKey = "test_key"
+    let apiKey2 = "test_key2"
+    let deploymentKey = "deplyoment_key"
+    let analytics = MockAnalyticsClient()
+    lazy var experiment = Experiment.initialize(apiKey: apiKey, config: .init())
+    lazy var experiment2 = Experiment.initialize(apiKey: apiKey2, config: .init())
+    lazy var context = AmplitudeContext(apiKey: apiKey, instanceName: "instance")
+    lazy var context2 = AmplitudeContext(apiKey: apiKey, instanceName: "instance2")
+
+    func testExternalClientSetup() {
+        let experimentPlugin = ExperimentPlugin(experiment: experiment)
+
+        XCTAssertIdentical(experimentPlugin.experiment, experiment)
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+
+        XCTAssertIdentical(experimentPlugin.experiment, experiment)
+    }
+
+    func testExternalClientPluginLookup() {
+        let experimentPlugin = ExperimentPlugin(experiment: experiment)
+
+        let pluginHost = MockPluginHost()
+        pluginHost.add(plugin: experimentPlugin)
+
+        XCTAssertIdentical(pluginHost.experiment, experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: apiKey), experiment)
+
+        let experimentPlugin2 = ExperimentPlugin(experiment: experiment2)
+        pluginHost.add(plugin: experimentPlugin2)
+
+        XCTAssertNil(pluginHost.experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: apiKey2), experiment2)
+
+        XCTAssert(pluginHost.has(plugin: experimentPlugin))
+        XCTAssert(pluginHost.has(plugin: experimentPlugin2))
+    }
+
+    func testHostedClientDeploymentKeySetup() {
+        let experimentPlugin = ExperimentPlugin(config: .init(deploymentKey: deploymentKey))
+
+        XCTAssertNil(experimentPlugin.experiment)
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+        let experiment = experimentPlugin.experiment as? DefaultExperimentClient
+
+        XCTAssertNotNil(experiment)
+        XCTAssertEqual(experiment?.apiKey, deploymentKey)
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+
+        XCTAssertNotNil(experimentPlugin.experiment)
+        XCTAssertIdentical(experiment, experimentPlugin.experiment)
+        XCTAssertEqual(experiment?.apiKey, deploymentKey)
+    }
+
+    func testHostedClientDeploymentKeyPluginLookup() {
+        let experimentPlugin = ExperimentPlugin(config: .init(deploymentKey: deploymentKey))
+        let pluginHost = MockPluginHost()
+        pluginHost.add(plugin: experimentPlugin)
+
+        XCTAssertNil(pluginHost.experiment)
+        XCTAssertNil(pluginHost.experiment(apiKey: deploymentKey))
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+        let experiment = pluginHost.experiment as? DefaultExperimentClient
+
+        XCTAssertNotNil(experiment)
+        XCTAssertEqual(experiment?.apiKey, deploymentKey)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: deploymentKey), experiment)
+
+        // experimentPlugin2 should not be added as its api key should conflict
+        let experimentPlugin2 = ExperimentPlugin(config: .init(deploymentKey: deploymentKey))
+        pluginHost.add(plugin: experimentPlugin2)
+
+        XCTAssertIdentical(pluginHost.experiment, experiment)
+        XCTAssert(pluginHost.has(plugin: experimentPlugin))
+        XCTAssertFalse(pluginHost.has(plugin: experimentPlugin2))
+
+        // experimentPlugin3 should be added as its api key is unique
+        let experimentPlugin3 = ExperimentPlugin(experiment: experiment2)
+        pluginHost.add(plugin: experimentPlugin3)
+
+        XCTAssert(pluginHost.has(plugin: experimentPlugin))
+        XCTAssert(pluginHost.has(plugin: experimentPlugin3))
+        XCTAssertNil(pluginHost.experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: deploymentKey), experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: apiKey2), experiment2)
+    }
+
+    func testHostedClientApiKeySetup() {
+        let experimentPlugin = ExperimentPlugin(config: .init())
+
+        XCTAssertNil(experimentPlugin.experiment)
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+        let experiment = experimentPlugin.experiment as? DefaultExperimentClient
+
+        XCTAssertNotNil(experiment)
+        XCTAssertEqual(experiment?.apiKey, apiKey)
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context2)
+
+        XCTAssertNotNil(experimentPlugin.experiment)
+        XCTAssertNotIdentical(experiment, experimentPlugin.experiment)
+        XCTAssertEqual(experiment?.apiKey, apiKey)
+    }
+
+    func testHostedClientApiKeyPluginLookup() {
+        let experimentPlugin = ExperimentPlugin(config: .init())
+        let pluginHost = MockPluginHost()
+        pluginHost.add(plugin: experimentPlugin)
+
+        XCTAssertNil(pluginHost.experiment)
+        XCTAssertNil(pluginHost.experiment(apiKey: apiKey))
+
+        experimentPlugin.setup(analyticsClient: analytics, amplitudeContext: context)
+        let experiment = pluginHost.experiment as? DefaultExperimentClient
+
+        XCTAssertNotNil(experiment)
+        XCTAssertEqual(experiment?.apiKey, apiKey)
+        XCTAssertNil(pluginHost.experiment(apiKey: apiKey))
+        XCTAssertIdentical(pluginHost.experiment(apiKey: nil), experiment)
+
+        // experimentPlugin2 should not be added as its api key should conflict
+        let experimentPlugin2 = ExperimentPlugin(config: .init())
+        pluginHost.add(plugin: experimentPlugin2)
+
+        XCTAssertIdentical(pluginHost.experiment, experiment)
+        XCTAssert(pluginHost.has(plugin: experimentPlugin))
+        XCTAssertFalse(pluginHost.has(plugin: experimentPlugin2))
+
+        // experimentPlugin3 should be added as its api key is unique
+        let experimentPlugin3 = ExperimentPlugin(experiment: experiment2)
+        pluginHost.add(plugin: experimentPlugin3)
+
+        XCTAssert(pluginHost.has(plugin: experimentPlugin))
+        XCTAssert(pluginHost.has(plugin: experimentPlugin3))
+        XCTAssertNil(pluginHost.experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: nil), experiment)
+        XCTAssertIdentical(pluginHost.experiment(apiKey: apiKey2), experiment2)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+class MockPluginHost: PluginHost {
+
+    private var plugins: [UniversalPlugin] = []
+
+    func add(plugin: UniversalPlugin) {
+        if let name = plugin.name, self.plugin(name: name) != nil {
+            return
+        }
+        plugins.append(plugin)
+    }
+
+    func has(plugin: UniversalPlugin) -> Bool {
+        return plugins.contains { $0 === plugin }
+    }
+
+    func plugin(name: String) -> (any UniversalPlugin)? {
+        return plugins.first { $0.name == name }
+    }
+
+    func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType] {
+        var plugins: [PluginType] = []
+
+        self.plugins.forEach {
+            if let plugin = $0 as? PluginType {
+                plugins.append(plugin)
+            }
+        }
+
+        return plugins
+    }
+}
+
+struct MockIdentity: AnalyticsIdentity {
+
+    var deviceId: String? = nil
+    var userId: String? = nil
+    var userProperties: [String : Any] = [:]
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+class MockAnalyticsClient: AnalyticsClient {
+
+    var identity: MockIdentity
+    var sessionId: Int64
+    var optOut: Bool
+
+    init(identity: MockIdentity = MockIdentity(), sessionId: Int64 = -1, optOut: Bool = false) {
+        self.identity = identity
+        self.sessionId = sessionId
+        self.optOut = optOut
+    }
+
+    func track(eventType: String, eventProperties: [String: Any]?) {
+
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Initial Unified SDK integration for Experiment

Adds `AmplitudeCore` dependency and new `ExperimentPlugin` to directly integrate with Amplitude, bypassing analytics-connector.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
