### PR TITLE
fix: avoid supported version deprecated warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.0.0
@@ -23,7 +23,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: [authorize]
     env:
       SWIFT_DOC_VERSION: '1.0.0-rc.1'
@@ -32,9 +32,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Xcode 16.1
+      - name: Set Xcode 16.3
         run: |
-          sudo xcode-select -switch /Applications/Xcode_16.1.app
+          sudo xcode-select -switch /Applications/Xcode_16.3.app
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout 
         uses: actions/checkout@v2
 
-      - name: Set Xcode 15
+      - name: Set Xcode 16.3
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.1.app
+          sudo xcode-select -switch /Applications/Xcode_16.3.app
 
       - name: Carthage Bootstrap
         run: carthage bootstrap --use-xcframeworks
@@ -26,7 +26,7 @@ jobs:
             -project Experiment.xcodeproj \
             -scheme Experiment \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5'
 
       - name: macOS Tests
         run: |
@@ -34,7 +34,7 @@ jobs:
             -project Experiment.xcodeproj \
             -scheme Experiment \
             -sdk macosx \
-            -destination 'platform=macosx' \
+            -destination 'platform=macOS' \
             test
 
       - name: tvOS Tests

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -1,0 +1,44 @@
+// swift-tools-version:6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "experiment-ios-client",
+    platforms: [
+        .iOS(.v12),
+        .macOS(.v10_13),
+        .tvOS(.v12),
+        .watchOS(.v4),
+        .visionOS(.v1),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Experiment",
+            targets: ["Experiment"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.12"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Experiment",
+            dependencies: [
+                .product(name: "AnalyticsConnector", package: "analytics-connector-ios"),
+                .product(name: "AmplitudeCoreFramework", package: "AmplitudeCore-Swift"),
+            ],
+            path: "Sources/Experiment",
+            exclude: ["Info.plist"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
+        .testTarget(
+            name: "ExperimentTests",
+            dependencies: ["Experiment"],
+            path: "Tests/ExperimentTests",
+            exclude: ["Info.plist"]),
+    ]
+)


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

- Add a Swift 6.2-specific Package.swift, in which the supported versions of iOS and watchOS are raised to 12 to avoid warnings in Xcode 26

  We will also make similar changes in AmplitudeCore-Swift. Because the Experiment depends on AmplitudeCore, it’s necessary to modify it first.

   Related Issue: https://github.com/amplitude/Amplitude-Swift/issues/314

- Updated and fixed the workflow configuration.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
