### PR TITLE
fix: swift 6.2 manifest compiles in swift 6 language mode

### DIFF
--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -34,7 +34,8 @@ let package = Package(
             ],
             path: "Sources/Experiment",
             exclude: ["Info.plist"],
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
         .testTarget(
             name: "ExperimentTests",
             dependencies: ["Experiment"],


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

This PR specifies the Swift 5 language mode in the Swift 6.2 manifest introduced by #76.

Every package manifest with swift-tools-version 6.0 or greater compiles all target in language mode v6 by default; every target that only compiles in v5, like `Experiment`, needs to actively be configured with that setting.

It resolves #77 with the following build error:

<img width="662" height="263" alt="Screenshot 2025-08-31 at 15 50 04" src="https://github.com/user-attachments/assets/3ab17859-af63-4524-b0b5-7b07a762e39f" />

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
