### PR TITLE
fix: tests assertion ignore evaluationId

### DIFF
--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -15,7 +15,7 @@ let KEY = "sdk-ci-test"
 let INITIAL_KEY = "initial-key"
 
 let testUser = ExperimentUserBuilder().userId("test_user").build()
-let serverVariant = Variant("on", payload: "payload", key: "on")
+let serverVariant = Variant("on", payload: "payload", key: "on", metadata: ["evaluationId": ""])
 let fallbackVariant = Variant("fallback", payload: "payload")
 let initialVariant = Variant("initial")
 let initialVariants: [String: Variant] = [
@@ -23,7 +23,7 @@ let initialVariants: [String: Variant] = [
     KEY: Variant("off")
 ]
 let KEY2 = "sdk-ci-test-2"
-let serverVariant2 = Variant("on")
+let serverVariant2 = Variant("on", metadata: ["evaluationId": ""])
 
 func assertVariantEqual(expected: Variant, actual: Variant) {
     var metadata = expected.metadata ?? (actual.metadata != nil ? [:] : nil)

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -25,6 +25,13 @@ let initialVariants: [String: Variant] = [
 let KEY2 = "sdk-ci-test-2"
 let serverVariant2 = Variant("on")
 
+func assertVariantEqual(expected: Variant, actual: Variant) {
+    var metadata = expected.metadata ?? (actual.metadata != nil ? [:] : nil)
+    metadata?["evaluationId"] = actual.metadata?["evaluationId"]
+    let matchedExpected = Variant(key: expected.key, value: expected.value, payload: expected.payload, expKey: expected.expKey, metadata: metadata)
+    XCTAssertEqual(matchedExpected, actual)
+}
+
 class ExperimentClientTests: XCTestCase {
     
     func testFetch() {
@@ -39,7 +46,7 @@ class ExperimentClientTests: XCTestCase {
         client.fetch(user: testUser) { (client, error) in
             XCTAssertNil(error)
             let variant = client.variant(KEY, fallback: nil)
-            XCTAssertEqual(serverVariant, variant)
+            assertVariantEqual(expected: serverVariant, actual: variant)
             s.signal()
         }
         s.wait()
@@ -89,7 +96,7 @@ class ExperimentClientTests: XCTestCase {
         // Wait for retry to succeed
         _ = s.wait(timeout: .now() + .seconds(2))
         let variant = client.variant(KEY, fallback: nil)
-        XCTAssertEqual(serverVariant, variant)
+        assertVariantEqual(expected: serverVariant, actual: variant)
     }
     
     func testFallbackVariantReturnedInCorrectOrder() {
@@ -126,9 +133,9 @@ class ExperimentClientTests: XCTestCase {
         client.fetch(user: testUser, options: options) { (client, error) in
             XCTAssertNil(error)
             let variant = client.variant(KEY, fallback: nil)
-            XCTAssertEqual(serverVariant, variant)
+            assertVariantEqual(expected: serverVariant, actual: variant)
             let variant2 = client.variant(KEY2, fallback: nil)
-            XCTAssertEqual(serverVariant2, variant2)
+            assertVariantEqual(expected: serverVariant2, actual: variant2)
             s.signal()
         }
         s.wait()
@@ -490,7 +497,7 @@ class ExperimentClientTests: XCTestCase {
         XCTAssertEqual(nil, variant.value)
         client.fetchBlocking(user: user)
         variant = client.variant("sdk-ci-test")
-        XCTAssertEqual(Variant(key: "on", value: "on", payload: "payload"), variant)
+        assertVariantEqual(expected: Variant(key: "on", value: "on", payload: "payload"), actual: variant)
     }
     
     // Server Zone Tests
@@ -746,7 +753,7 @@ class ExperimentClientTests: XCTestCase {
             .build()
         client.startBlocking(user: user)
         let variant = client.variant("sdk-ci-test")
-        XCTAssertEqual(Variant(key: "on", value: "on", payload: "payload"), variant)
+        assertVariantEqual(expected: Variant(key: "on", value: "on", payload: "payload"), actual: variant)
         XCTAssertEqual(1, exposureTrackingProvider.trackCount)
         XCTAssertEqual("sdk-ci-test", exposureTrackingProvider.lastExposure?.flagKey)
         XCTAssertEqual("on", exposureTrackingProvider.lastExposure?.variant)

--- a/Tests/ExperimentTests/ObjectiveCTest.m
+++ b/Tests/ExperimentTests/ObjectiveCTest.m
@@ -32,7 +32,9 @@ void assertVariantEqualExpected(Variant *expected, Variant *actual) {
 @implementation ObjectiveCTest
 
 - (void)testObjectiveCBasic {
-    Variant *expectedVariant = [[Variant alloc] init:@"on" payload:@"payload" expKey:nil key:@"on" metadata:nil];
+    NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
+    metadata[@"evaluationId"] = @"";
+    Variant *expectedVariant = [[Variant alloc] init:@"on" payload:@"payload" expKey:nil key:@"on" metadata:metadata];
     
     ExperimentConfigBuilder *confBuilder = [ExperimentConfigBuilder new];
     confBuilder = [confBuilder debug:YES];

--- a/Tests/ExperimentTests/ObjectiveCTest.m
+++ b/Tests/ExperimentTests/ObjectiveCTest.m
@@ -9,6 +9,22 @@
 #import <Experiment/Experiment-Swift.h>
 #import <dispatch/dispatch.h>
 
+void assertVariantEqualExpected(Variant *expected, Variant *actual) {
+    NSMutableDictionary *metadata = [expected.metadata mutableCopy];
+    if (metadata == nil && actual.metadata != nil) {
+        metadata = [NSMutableDictionary dictionary];
+    }
+    if (metadata != nil && actual.metadata != nil) {
+        metadata[@"evaluationId"] = actual.metadata[@"evaluationId"];
+    }
+    
+    Variant *matchedExpected = [[Variant alloc] init:expected.value payload:expected.payload expKey:expected.expKey key:expected.key metadata:metadata];
+    
+    XCTAssertNotNil(actual.metadata[@"evaluationId"]);
+    XCTAssertEqualObjects(matchedExpected, actual);
+    XCTAssertTrue([matchedExpected isEqual:actual]);
+}
+
 @interface ObjectiveCTest : XCTestCase
 
 @end
@@ -31,7 +47,7 @@
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     [client fetchWithUser:user completion:^(id<ExperimentClient> _Nonnull client, NSError * _Nullable error) {
         Variant *variant = [client variant:@"sdk-ci-test"];
-        XCTAssertTrue([variant isEqual:expectedVariant]);
+        assertVariantEqualExpected(expectedVariant, variant);
         dispatch_semaphore_signal(sem);
     }];
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);


### PR DESCRIPTION
### Summary

Fix tests' assertions to only assert evaluationId to be not null. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no