### PR TITLE
feat: allow for better user defined logging behavior with logLevel and loggerProvider config fields

### DIFF
--- a/Experiment.xcodeproj/project.pbxproj
+++ b/Experiment.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		4E22BCAC2DCE99B70069239F /* ExperimentPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */; };
 		4EDAAFB02DB0609B00C90724 /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EDAAFAF2DB0609B00C90724 /* AmplitudeCoreFramework */; };
 		4EDAAFB22DB060A700C90724 /* ExperimentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */; };
+		E3200C2E2EBEB40400A99A62 /* DefaultLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3200C2D2EBEB40400A99A62 /* DefaultLogger.swift */; };
+		E394E4AE2EC3C12D00F4901A /* AmpLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E394E4AD2EC3C12900F4901A /* AmpLogger.swift */; };
+		E394E4B12EC3E26C00F4901A /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E394E4B02EC3E26C00F4901A /* LoggerTests.swift */; };
 		E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9030DB425B8AFC600BA1BA8 /* Variant.swift */; };
 		E914961925796DA800C64B38 /* Experiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E914960F25796DA800C64B38 /* Experiment.framework */; };
 		E914961E25796DA800C64B38 /* ExperimentClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E914961D25796DA800C64B38 /* ExperimentClientTests.swift */; };
@@ -108,6 +111,9 @@
 		3E0148332921C08D004D259D /* FetchOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchOptions.swift; sourceTree = "<group>"; };
 		4E22BCAB2DCE99B00069239F /* ExperimentPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPluginTests.swift; sourceTree = "<group>"; };
 		4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentPlugin.swift; sourceTree = "<group>"; };
+		E3200C2D2EBEB40400A99A62 /* DefaultLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLogger.swift; sourceTree = "<group>"; };
+		E394E4AD2EC3C12900F4901A /* AmpLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpLogger.swift; sourceTree = "<group>"; };
+		E394E4B02EC3E26C00F4901A /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		E9030DB425B8AFC600BA1BA8 /* Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variant.swift; sourceTree = "<group>"; };
 		E914960F25796DA800C64B38 /* Experiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Experiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E914961225796DA800C64B38 /* Experiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Experiment.h; sourceTree = "<group>"; };
@@ -180,36 +186,38 @@
 		E914961125796DA800C64B38 /* Experiment */ = {
 			isa = PBXGroup;
 			children = (
-				4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */,
-				201FCB5F2BBB879500F07EC1 /* PrivacyInfo.xcprivacy */,
-				20F8C8C32AAFE2A100B5717C /* Murmur3.swift */,
-				20F8C8C62AAFE2B300B5717C /* SemanticVersion.swift */,
-				20F8C8C92AAFE2BF00B5717C /* TopologicalSort.swift */,
-				20F8C8CC2AAFF6CB00B5717C /* EvaluationFlag.swift */,
-				20F8C8CF2AAFF6DC00B5717C /* Selectable.swift */,
-				20F8C8D22AAFF6E900B5717C /* EvaluationEngine.swift */,
-				3E0148332921C08D004D259D /* FetchOptions.swift */,
-				E9C5D9192579718E00867574 /* Storage.swift */,
-				E9C5D91A2579718E00867574 /* ExperimentUserProvider.swift */,
-				E9C5D9172579718E00867574 /* Experiment.swift */,
-				E9C5D9122579718E00867574 /* DefaultUserProvider.swift */,
-				E9C5D9132579718E00867574 /* ExperimentClient.swift */,
-				E9C5D9152579718E00867574 /* ExperimentConfig.swift */,
-				E9C5D9162579718E00867574 /* ExperimentUser.swift */,
+				E394E4AD2EC3C12900F4901A /* AmpLogger.swift */,
+				20E6CCC82ABB488000F72385 /* AnyCodable.swift */,
 				20B1BB8D2683CC2A003A960F /* Backoff.swift */,
-				E9030DB425B8AFC600BA1BA8 /* Variant.swift */,
-				E914961225796DA800C64B38 /* Experiment.h */,
-				E914961325796DA800C64B38 /* Info.plist */,
-				207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */,
-				207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */,
-				207CBB9726AB8C9800A0029D /* ExposureEvent.swift */,
 				20C9FA372787621100A4D530 /* ConnectorExposureTrackingProvider.swift */,
 				20C9FA3D2787621B00A4D530 /* ConnectorUserProvider.swift */,
-				20732759278E42B0002BBD43 /* SessionAnalyticsProvider.swift */,
-				207C96E527B71262008EE143 /* ExposureTrackingProvider.swift */,
+				E9C5D9122579718E00867574 /* DefaultUserProvider.swift */,
+				20F8C8D22AAFF6E900B5717C /* EvaluationEngine.swift */,
+				E3200C2D2EBEB40400A99A62 /* DefaultLogger.swift */,
+				20F8C8CC2AAFF6CB00B5717C /* EvaluationFlag.swift */,
+				E914961225796DA800C64B38 /* Experiment.h */,
+				E9C5D9172579718E00867574 /* Experiment.swift */,
+				207CBB9326AB8BD400A0029D /* ExperimentAnalyticsEvent.swift */,
+				207CBB8F26AB8B9900A0029D /* ExperimentAnalyticsProvider.swift */,
+				E9C5D9132579718E00867574 /* ExperimentClient.swift */,
+				E9C5D9152579718E00867574 /* ExperimentConfig.swift */,
+				4EDAAFB12DB060A600C90724 /* ExperimentPlugin.swift */,
+				E9C5D9162579718E00867574 /* ExperimentUser.swift */,
+				E9C5D91A2579718E00867574 /* ExperimentUserProvider.swift */,
 				207C96EB27B71770008EE143 /* Exposure.swift */,
+				207CBB9726AB8C9800A0029D /* ExposureEvent.swift */,
+				207C96E527B71262008EE143 /* ExposureTrackingProvider.swift */,
+				3E0148332921C08D004D259D /* FetchOptions.swift */,
+				E914961325796DA800C64B38 /* Info.plist */,
+				20F8C8C32AAFE2A100B5717C /* Murmur3.swift */,
+				201FCB5F2BBB879500F07EC1 /* PrivacyInfo.xcprivacy */,
+				20F8C8CF2AAFF6DC00B5717C /* Selectable.swift */,
+				20F8C8C62AAFE2B300B5717C /* SemanticVersion.swift */,
+				20732759278E42B0002BBD43 /* SessionAnalyticsProvider.swift */,
+				E9C5D9192579718E00867574 /* Storage.swift */,
+				20F8C8C92AAFE2BF00B5717C /* TopologicalSort.swift */,
 				207C96EF27B719F2008EE143 /* UserSessionExposureTracker.swift */,
-				20E6CCC82ABB488000F72385 /* AnyCodable.swift */,
+				E9030DB425B8AFC600BA1BA8 /* Variant.swift */,
 			);
 			path = Experiment;
 			sourceTree = "<group>";
@@ -235,6 +243,7 @@
 				20C9FA43278791E400A4D530 /* ConnectorIntegrationTests.swift */,
 				2047CE302809FCD9002D2B06 /* UserSessionExposureTrackerTests.swift */,
 				20A5A6E02AC3583E00047E7F /* LoadStoreCacheTests.swift */,
+				E394E4B02EC3E26C00F4901A /* LoggerTests.swift */,
 			);
 			path = ExperimentTests;
 			sourceTree = "<group>";
@@ -375,10 +384,12 @@
 				207C96E627B71262008EE143 /* ExposureTrackingProvider.swift in Sources */,
 				20E6CCC92ABB488000F72385 /* AnyCodable.swift in Sources */,
 				207C96F027B719F2008EE143 /* UserSessionExposureTracker.swift in Sources */,
+				E3200C2E2EBEB40400A99A62 /* DefaultLogger.swift in Sources */,
 				E9C5D9232579718E00867574 /* ExperimentUserProvider.swift in Sources */,
 				E9C5D91F2579718E00867574 /* ExperimentUser.swift in Sources */,
 				3E0148342921C08D004D259D /* FetchOptions.swift in Sources */,
 				E9C5D91C2579718E00867574 /* ExperimentClient.swift in Sources */,
+				E394E4AE2EC3C12D00F4901A /* AmpLogger.swift in Sources */,
 				E9030DB525B8AFC600BA1BA8 /* Variant.swift in Sources */,
 				20C9FA3E2787621B00A4D530 /* ConnectorUserProvider.swift in Sources */,
 				207C96EC27B71770008EE143 /* Exposure.swift in Sources */,
@@ -421,6 +432,7 @@
 				20B1BF21268BBDA4003A960F /* VariantTests.swift in Sources */,
 				20F8C8DB2AB0D36400B5717C /* HashX8632.swift in Sources */,
 				20F8C8D72AAFF9DA00B5717C /* Murmur3Tests.swift in Sources */,
+				E394E4B12EC3E26C00F4901A /* LoggerTests.swift in Sources */,
 				20A5A6E12AC3583E00047E7F /* LoadStoreCacheTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Experiment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Experiment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "46df71a785d3b1e2442dbf2040313c9e32a127b8e296ecdd48f9195f4b3e651d",
+  "pins" : [
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
+      "state" : {
+        "revision" : "dda4458213f3c83520bd730d2eaacca7e532f572",
+        "version" : "1.2.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "1d9b590e202c3e2abb27ccb6b5b5ae62145406f0",
+        "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/Experiment/AmpLogger.swift
+++ b/Sources/Experiment/AmpLogger.swift
@@ -1,0 +1,46 @@
+//
+//  AmpLogger.swift
+//  Experiment
+//
+//  Created by Kenneth Yeh on 11/11/25.
+//
+
+import Foundation
+import AmplitudeCore
+
+@objc
+@preconcurrency
+public class AmpLogger: NSObject, CoreLogger, @unchecked Sendable {
+
+    public var logLevel: LogLevel
+    public var loggerProvider: any CoreLogger
+
+    public init(logLevel: LogLevel = LogLevel.warn, loggerProvier: any CoreLogger) {
+        self.logLevel = logLevel
+        self.loggerProvider = loggerProvier
+    }
+
+    public func error(message: String) {
+        if logLevel.rawValue >=  LogLevel.error.rawValue {
+            loggerProvider.error(message: message)
+        }
+    }
+
+    public func warn(message: String) {
+        if logLevel.rawValue >=  LogLevel.warn.rawValue {
+            loggerProvider.warn(message: message)
+        }
+    }
+
+    public func log(message: String) {
+        if logLevel.rawValue >=  LogLevel.log.rawValue {
+            loggerProvider.log(message: message)
+        }
+    }
+
+    public func debug(message: String) {
+        if logLevel.rawValue >=  LogLevel.debug.rawValue {
+            loggerProvider.debug(message: message)
+        }
+    }
+}

--- a/Sources/Experiment/Backoff.swift
+++ b/Sources/Experiment/Backoff.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Brian Giori on 6/23/21.
 //
-
+import AmplitudeCore
 import Foundation
 
 internal class Backoff {
@@ -14,6 +14,7 @@ internal class Backoff {
     private let min: Int
     private let max: Int
     private let scalar: Float
+    private let logger: CoreLogger
 
     // Dispatch
     private let lock = DispatchSemaphore(value: 1)
@@ -24,11 +25,12 @@ internal class Backoff {
     private var cancelled: Bool = false
     private var fetchTask: URLSessionTask? = nil
 
-    init(attempts: Int, min: Int, max: Int, scalar: Float, queue: DispatchQueue = DispatchQueue(label: "com.amplitude.experiment.backoff", qos: .default)) {
+    init(attempts: Int, min: Int, max: Int, scalar: Float, logger: any CoreLogger, queue: DispatchQueue = DispatchQueue(label: "com.amplitude.experiment.backoff", qos: .default)) {
         self.attempts = attempts
         self.min = min
         self.max = max
         self.scalar = scalar
+        self.logger = logger
         self.fetchQueue = queue
     }
 
@@ -70,10 +72,10 @@ internal class Backoff {
             self.fetchTask = function() { error in
                 guard error != nil else {
                     // Success
-                    print("[Experiment] Retry success")
+                    self.logger.log(message: "Retry success")
                     return
                 }
-                print("[Experiment] Retry failure")
+                self.logger.log(message: "Retry failure")
                 // Retry the request function
                 let nextAttempt = attempt + 1
                 if nextAttempt < self.attempts {

--- a/Sources/Experiment/DefaultLogger.swift
+++ b/Sources/Experiment/DefaultLogger.swift
@@ -1,0 +1,36 @@
+//
+//  ConsoleLogger.swift
+//  Experiment
+//
+//  Default logger implementation using Apple's OSLog framework.
+//
+
+import AmplitudeCore
+import Foundation
+import os.log
+
+@preconcurrency
+public class DefaultLogger: CoreLogger, @unchecked Sendable {
+
+    private var logger: OSLog
+
+    public init() {
+        self.logger = OSLog(subsystem: "Experiment", category: "Logging")
+    }
+
+    public func error(message: String) {
+        os_log("Error: %@", log: logger, type: .error, message)
+    }
+
+    public func warn(message: String) {
+        os_log("Warn: %@", log: logger, type: .default, message)
+    }
+
+    public func log(message: String) {
+        os_log("Log: %@", log: logger, type: .info, message)
+    }
+
+    public func debug(message: String) {
+        os_log("Debug: %@", log: logger, type: .debug, message)
+    }
+}

--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2020 Amplitude. All rights reserved.
 //
 
+import AmplitudeCore
 import Foundation
 
 @objc public protocol ExperimentClient {
@@ -39,10 +40,11 @@ private let euFlagsServerUrl = "https://flag.lab.eu.amplitude.com";
 internal class DefaultExperimentClient : NSObject, ExperimentClient {
 
     let apiKey: String
-    
+    private let logger: any CoreLogger
+
     internal let variants: LoadStoreCache<Variant>
     private let variantsStorageQueue = DispatchQueue(label: "com.amplitude.experiment.VariantsStorageQueue", attributes: .concurrent)
-    
+
     internal let flags: LoadStoreCache<EvaluationFlag>
     private let flagsStorageQueue = DispatchQueue(label: "com.amplitude.experiment.VariantsStorageQueue", attributes: .concurrent)
 
@@ -78,6 +80,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
             configBuilder.flagConfigPollingIntervalMillis(minFlagConfigPollingIntervalMillis)
         }
         self.config = configBuilder.build()
+        self.logger = self.config.logger
         if config.userProvider != nil {
             self.userProvider = config.userProvider
         }
@@ -92,9 +95,9 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         } else {
             self.userSessionExposureTracker = nil
         }
-        self.variants = getVariantStorage(apiKey: self.apiKey, instanceName: self.config.instanceName, storage: storage)
+        self.variants = getVariantStorage(apiKey: self.apiKey, instanceName: self.config.instanceName, storage: storage, logger: self.logger)
         self.variants.load()
-        self.flags = getFlagStorage(apiKey: self.apiKey, instanceName: self.config.instanceName, storage: storage)
+        self.flags = getFlagStorage(apiKey: self.apiKey, instanceName: self.config.instanceName, storage: storage, logger: self.logger)
         self.flags.load()
         self.flags.mergeInitialFlagsWithStorage(config.initialFlags)
     }
@@ -252,7 +255,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
                 evaluationVariant.toVariant()
             }
         } catch {
-            print("[Experiment] encountered evaluation error: \(error)")
+            logger.error(message: "encountered evaluation error: \(error)")
             return [:]
         }
     }
@@ -409,11 +412,11 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
     
     private func flagsInternal(completion: ((Error?) -> Void)? = nil) {
         flagsQueue.async {
-            self.debug("Updating flag configurations")
+            self.logger.debug(message: "Updating flag configurations")
             return self.doFlags(timeoutMillis: self.config.fetchTimeoutMillis) { result in
                 switch result {
                 case .success(let flags):
-                    self.debug("Got \(flags.count) flag configurations")
+                    self.logger.debug(message: "Got \(flags.count) flag configurations")
                     self.flagsStorageQueue.sync(flags: .barrier) {
                         self.flags.clear()
                         self.flags.putAll(values: flags)
@@ -422,7 +425,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
                     }
                     completion?(nil)
                 case .failure(let error):
-                    print("[Expeirment] get flags failed: \(error)")
+                    self.logger.error(message: "get flags failed: \(error)")
                     completion?(error)
                 }
             }
@@ -465,7 +468,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
                 }
                 completion(Result.success(result))
             } catch {
-                print("[Experiment] Failed to parse flag data: \(error)")
+                self.logger.error(message: "Failed to parse flag data: \(error)")
                 completion(Result.failure(error))
             }
         }.resume()
@@ -483,9 +486,9 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         let userId = user.userId
         let deviceId = user.deviceId
         if userId == nil && deviceId == nil {
-            print("[Experiment] WARN: user id and device id are null; amplitude will not be able to resolve identity")
+            logger.warn(message: "user id and device id are null; amplitude will not be able to resolve identity")
         }
-        self.debug("Fetch variants for user: \(user)")
+        logger.debug(message: "Fetch variants for user: \(user)")
         // Build fetch request
         let userDictionary = user.toDictionary()
         guard let requestData = try? JSONSerialization.data(withJSONObject: userDictionary, options: []) else {
@@ -518,7 +521,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
                 completion(Result.failure(ExperimentError("Response is nil")))
                 return
             }
-            self.debug("Received fetch response: \(httpResponse)")
+            self.logger.debug(message: "Received fetch response: \(httpResponse)")
             guard httpResponse.statusCode == 200 else {
                 completion(Result.failure(FetchError(httpResponse.statusCode, "Error Response: status=\(httpResponse.statusCode)")))
                 return
@@ -530,10 +533,10 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
             do {
                 let variants = try self.parseResponseData(data)
                 let end = CFAbsoluteTimeGetCurrent()
-                self.debug("Fetched variants in \(end - start) s")
+                self.logger.debug(message: "Fetched variants in \(end - start) s")
                 completion(Result.success(variants))
             } catch {
-                print("[Experiment] Failed to parse response data: \(error)")
+                self.logger.error(message: "Failed to parse response data: \(error)")
                 completion(Result.failure(error))
             }
         }
@@ -549,7 +552,8 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
             attempts: fetchBackoffAttempts,
             min: fetchBackoffMinMillis,
             max: fetchBackoffMaxMillis,
-            scalar: fetchBackoffScalar
+            scalar: fetchBackoffScalar,
+            logger: logger
         )
         self.backoff?.start() { completion in
             return self.fetchInternal(user: user, timeoutMillis: fetchBackoffTimeout, retry: false, options: options) { result in
@@ -618,7 +622,7 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
                 self.variants.remove(key: key)
             }
             self.variants.store()
-            self.debug("Stored variants: \(variants)")
+            logger.debug(message: "Stored variants: \(variants)")
         }
     }
     
@@ -676,14 +680,6 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         }
     }
 
-    private func debug(_ msg: String) {
-        if self.config.debug {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-            print("\(formatter.string(from: Date())) [Experiment] \(msg)")
-        }
-    }
-    
     private func shouldRetryFetch(_ e: Error) -> Bool {
         guard let e = e as? FetchError else {
             return true

--- a/Sources/Experiment/ExperimentConfig.swift
+++ b/Sources/Experiment/ExperimentConfig.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AmplitudeCore
 
 @objc public enum Source: Int {
     case LocalStorage = 0
@@ -19,7 +20,9 @@ import Foundation
 
 @objc public class ExperimentConfig : NSObject {
 
+    @available(*, deprecated, message: "Use logLevel instead. Set to .DEBUG to enable debug logging")
     @objc public let debug: Bool
+    @objc public let logger: AmpLogger
     @objc public let instanceName: String
     @objc public let fallbackVariant: Variant
     @objc public let initialFlags: String?
@@ -42,6 +45,7 @@ import Foundation
     
     @objc public override init() {
         self.debug = ExperimentConfig.Defaults.debug
+        self.logger = AmpLogger(logLevel: ExperimentConfig.Defaults.logLevel, loggerProvier: ExperimentConfig.Defaults.loggerProvider)
         self.instanceName = ExperimentConfig.Defaults.instanceName
         self.fallbackVariant = ExperimentConfig.Defaults.fallbackVariant
         self.initialFlags = ExperimentConfig.Defaults.initialFlags
@@ -64,6 +68,7 @@ import Foundation
     
     internal init(builder: ExperimentConfigBuilder) {
         self.debug = builder.debug
+        self.logger = AmpLogger(logLevel: builder.logLevel, loggerProvier: builder.loggerProvider)
         self.instanceName = builder.instanceName
         self.fallbackVariant = builder.fallbackVariant
         self.initialFlags = builder.initialFlags
@@ -86,6 +91,7 @@ import Foundation
     
     internal init(builder: ExperimentConfig.Builder) {
         self.debug = builder.debug
+        self.logger = AmpLogger(logLevel: builder.logLevel, loggerProvier: builder.loggerProvider)
         self.instanceName = builder.instanceName
         self.fallbackVariant = builder.fallbackVariant
         self.initialFlags = builder.initialFlags
@@ -107,6 +113,8 @@ import Foundation
     }
 
     public struct Defaults {
+        public static let logLevel: LogLevel = .warn
+        public static let loggerProvider: CoreLogger = DefaultLogger()
         public static let debug: Bool = false
         public static let instanceName: String = "$default_instance"
         public static let fallbackVariant: Variant = Variant()
@@ -130,7 +138,9 @@ import Foundation
     
     @available(*, deprecated, message: "Use ExperimentConfigBuilder instead")
     public class Builder {
-            
+
+        internal var logLevel: LogLevel = ExperimentConfig.Defaults.logLevel
+        internal var loggerProvider: any CoreLogger = ExperimentConfig.Defaults.loggerProvider
         internal var debug: Bool = ExperimentConfig.Defaults.debug
         internal var instanceName = ExperimentConfig.Defaults.instanceName
         internal var fallbackVariant: Variant = ExperimentConfig.Defaults.fallbackVariant
@@ -158,9 +168,25 @@ import Foundation
         @discardableResult
         public func debug(_ debug: Bool) -> Builder {
             self.debug = debug
+            // For backward compatibility: only change logLevel when debug is true
+            if debug {
+                self.logLevel = .debug
+            }
             return self
         }
-        
+
+        @discardableResult
+        public func logLevel(_ logLevel: LogLevel) -> Builder {
+            self.logLevel = logLevel
+            return self
+        }
+
+        @discardableResult
+        public func loggerProvider(_ loggerProvider: any CoreLogger) -> Builder {
+            self.loggerProvider = loggerProvider
+            return self
+        }
+
         @discardableResult
         public func instanceName(_ instanceName: String) -> Builder {
             self.instanceName = instanceName
@@ -290,6 +316,8 @@ import Foundation
         let fetchOnStart = self.fetchOnStart?.boolValue
         let builder = ExperimentConfigBuilder()
             .debug(self.debug)
+            .logLevel(self.logger.logLevel)
+            .loggerProvider(self.logger.loggerProvider)
             .instanceName(self.instanceName)
             .fallbackVariant(self.fallbackVariant)
             .initialFlags(self.initialFlags)
@@ -315,7 +343,9 @@ import Foundation
 }
 
 @objc public class ExperimentConfigBuilder : NSObject {
-    
+
+    internal var logLevel: LogLevel = ExperimentConfig.Defaults.logLevel
+    internal var loggerProvider: CoreLogger = ExperimentConfig.Defaults.loggerProvider
     internal var debug: Bool = ExperimentConfig.Defaults.debug
     internal var instanceName: String = ExperimentConfig.Defaults.instanceName
     internal var fallbackVariant: Variant = ExperimentConfig.Defaults.fallbackVariant
@@ -339,9 +369,25 @@ import Foundation
     @discardableResult
     @objc public func debug(_ debug: Bool) -> ExperimentConfigBuilder {
         self.debug = debug
+        // For backward compatibility: only change logLevel when debug is true
+        if debug {
+            self.logLevel = .debug
+        }
         return self
     }
-    
+
+    @discardableResult
+    @objc public func logLevel(_ logLevel: LogLevel) -> ExperimentConfigBuilder {
+        self.logLevel = logLevel
+        return self
+    }
+
+    @discardableResult
+    @objc public func loggerProvider(_ loggerProvider: CoreLogger) -> ExperimentConfigBuilder {
+        self.loggerProvider = loggerProvider
+        return self
+    }
+
     @discardableResult
     @objc public func instanceName(_ instanceName: String) -> ExperimentConfigBuilder {
         self.instanceName = instanceName

--- a/Sources/Experiment/ExperimentPlugin.swift
+++ b/Sources/Experiment/ExperimentPlugin.swift
@@ -122,6 +122,7 @@ public class ExperimentPlugin: NSObject, UniversalPlugin {
                       amplitudeContext: AmplitudeCore.AmplitudeContext) {
         self.context = amplitudeContext
         self.analytics = analyticsClient
+        self.logger = amplitudeContext.logger
 
         switch mode {
         case .hosted(let config):

--- a/Tests/ExperimentTests/LoadStoreCacheTests.swift
+++ b/Tests/ExperimentTests/LoadStoreCacheTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian Giori on 9/26/23.
 //
 
+import AmplitudeCore
 import Foundation
 import XCTest
 @testable import Experiment
@@ -13,7 +14,7 @@ class LoadStoreCacheTests: XCTestCase {
     
     func testCacheMethods() {
         let storage = InMemoryStorage()
-        let cache = LoadStoreCache<Variant>(namespace: "test", storage: storage)
+        let cache = LoadStoreCache<Variant>(namespace: "test", storage: storage, logger: AmpLogger(logLevel: LogLevel.debug, loggerProvier: DefaultLogger()))
         // Put / Get
         cache.put(key: "flag-key-1", value: Variant(key: "on", value: "on"))
         let variant = cache.get(key: "flag-key-1")
@@ -45,7 +46,7 @@ class LoadStoreCacheTests: XCTestCase {
     func testLoad() {
         let namespace = "test"
         let storage = InMemoryStorage()
-        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage)
+        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage, logger: AmpLogger(logLevel: LogLevel.debug, loggerProvier: DefaultLogger()))
         let testData = """
         {"flag-key-1":{"key":"on","value":"on"}}
         """.data(using: .utf8)!
@@ -60,7 +61,7 @@ class LoadStoreCacheTests: XCTestCase {
     func testLoadOverwritesCache() {
         let namespace = "test"
         let storage = InMemoryStorage()
-        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage)
+        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage, logger: AmpLogger(logLevel: LogLevel.debug, loggerProvier: DefaultLogger()))
         let testData = """
         {"flag-key-1":{"key":"off","value":"off"}}
         """.data(using: .utf8)!
@@ -80,7 +81,7 @@ class LoadStoreCacheTests: XCTestCase {
     func testStore() {
         let namespace = "test"
         let storage = InMemoryStorage()
-        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage)
+        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage, logger: AmpLogger(logLevel: LogLevel.debug, loggerProvier: DefaultLogger()))
         cache.put(key: "flag-key-1", value: Variant(key: "on", value: "on"))
         cache.store(async: false)
         let storageData = storage.get(key: namespace)
@@ -92,7 +93,7 @@ class LoadStoreCacheTests: XCTestCase {
     func testStoreOverwritesStorage() {
         let namespace = "test"
         let storage = InMemoryStorage()
-        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage)
+        let cache = LoadStoreCache<Variant>(namespace: namespace, storage: storage, logger: AmpLogger(logLevel: LogLevel.debug, loggerProvier: DefaultLogger()))
         let initialData = """
         {"flag-key-1":{"key":"on","value":"on"}}
         """.data(using: .utf8)!

--- a/Tests/ExperimentTests/LoggerTests.swift
+++ b/Tests/ExperimentTests/LoggerTests.swift
@@ -1,0 +1,179 @@
+//
+//  LoggerTests.swift
+//  ExperimentTests
+//
+//  Tests for AmpLogger log level filtering and configuration
+//
+
+import AmplitudeCore
+import XCTest
+@testable import Experiment
+
+class MockCoreLogger: CoreLogger {
+    var errorMessages: [String] = []
+    var warnMessages: [String] = []
+    var logMessages: [String] = []
+    var debugMessages: [String] = []
+
+    func error(message: String) {
+        errorMessages.append(message)
+    }
+
+    func warn(message: String) {
+        warnMessages.append(message)
+    }
+
+    func log(message: String) {
+        logMessages.append(message)
+    }
+
+    func debug(message: String) {
+        debugMessages.append(message)
+    }
+}
+
+class LoggerTests: XCTestCase {
+
+    // MARK: - Test Helpers
+
+    private func logAllLevels(_ logger: CoreLogger) {
+        logger.error(message: "Test error")
+        logger.warn(message: "Test warn")
+        logger.log(message: "Test log")
+        logger.debug(message: "Test debug")
+    }
+
+    private func assertMessageCounts(_ logger: MockCoreLogger,
+                                     error: Int, warn: Int, log: Int, debug: Int,
+                                     file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(logger.errorMessages.count, error, file: file, line: line)
+        XCTAssertEqual(logger.warnMessages.count, warn, file: file, line: line)
+        XCTAssertEqual(logger.logMessages.count, log, file: file, line: line)
+        XCTAssertEqual(logger.debugMessages.count, debug, file: file, line: line)
+    }
+
+    // MARK: - AmpLogger Log Level Filtering Tests
+
+    func testAmpLoggerLogLevelOff() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(logLevel: .off, loggerProvier: mockLogger)
+
+        logAllLevels(ampLogger)
+        assertMessageCounts(mockLogger, error: 0, warn: 0, log: 0, debug: 0)
+    }
+
+    func testAmpLoggerLogLevelError() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(logLevel: .error, loggerProvier: mockLogger)
+
+        logAllLevels(ampLogger)
+        assertMessageCounts(mockLogger, error: 1, warn: 0, log: 0, debug: 0)
+        XCTAssertEqual(mockLogger.errorMessages[0], "Test error")
+    }
+
+    func testAmpLoggerLogLevelWarn() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(logLevel: .warn, loggerProvier: mockLogger)
+
+        logAllLevels(ampLogger)
+        assertMessageCounts(mockLogger, error: 1, warn: 1, log: 0, debug: 0)
+    }
+
+    func testAmpLoggerLogLevelLog() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(logLevel: .log, loggerProvier: mockLogger)
+
+        logAllLevels(ampLogger)
+        assertMessageCounts(mockLogger, error: 1, warn: 1, log: 1, debug: 0)
+    }
+
+    func testAmpLoggerLogLevelDebug() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(logLevel: .debug, loggerProvier: mockLogger)
+
+        logAllLevels(ampLogger)
+        assertMessageCounts(mockLogger, error: 1, warn: 1, log: 1, debug: 1)
+    }
+
+    func testAmpLoggerDefaultLogLevel() {
+        let mockLogger = MockCoreLogger()
+        let ampLogger = AmpLogger(loggerProvier: mockLogger)
+
+        XCTAssertEqual(ampLogger.logLevel, .warn)
+    }
+
+    // MARK: - ExperimentConfig Tests
+
+    func testExperimentConfigDefaultLogger() {
+        let config = ExperimentConfig()
+
+        XCTAssertEqual(config.logger.logLevel, .warn)
+        XCTAssertTrue(config.logger.loggerProvider is DefaultLogger)
+    }
+
+    // MARK: - ExperimentConfigBuilder Tests
+
+    func testExperimentConfigBuilderDefaultLogger() {
+        let config = ExperimentConfigBuilder()
+            .build()
+
+        XCTAssertEqual(config.logger.logLevel, .warn)
+        XCTAssertTrue(config.logger.loggerProvider is DefaultLogger)
+    }
+
+    func testExperimentConfigBuilderSetLogLevel() {
+        let config = ExperimentConfigBuilder()
+            .logLevel(.log)
+            .build()
+
+        XCTAssertEqual(config.logger.logLevel, .log)
+    }
+
+    func testExperimentConfigBuilderSetDebug() {
+        let config = ExperimentConfigBuilder()
+            .debug(true)
+            .build()
+
+        XCTAssertEqual(config.debug, true)
+        XCTAssertEqual(config.logger.logLevel, .debug)
+    }
+
+    func testExperimentConfigBuilderWithCustomLogger() {
+        let customLogger = MockCoreLogger()
+        let config = ExperimentConfigBuilder()
+            .loggerProvider(customLogger)
+            .build()
+
+        XCTAssertTrue(config.logger.loggerProvider is MockCoreLogger)
+    }
+
+    func testExperimentConfigBuilderLogLevelWithCustomLogger() {
+        let customLogger = MockCoreLogger()
+        let config = ExperimentConfigBuilder()
+            .loggerProvider(customLogger)
+            .logLevel(.debug)
+            .build()
+
+        XCTAssertEqual(config.logger.logLevel, .debug)
+        XCTAssertTrue(config.logger.loggerProvider is MockCoreLogger)
+    }
+
+    func testExperimentConfigBuilderDebugOverridesLogLevel() {
+        let config = ExperimentConfigBuilder()
+            .logLevel(.error)
+            .debug(true)
+            .build()
+
+        XCTAssertEqual(config.logger.logLevel, .debug)
+    }
+
+    func testExperimentConfigBuilderLogLevelAfterDebug() {
+        let config = ExperimentConfigBuilder()
+            .debug(true)
+            .logLevel(.warn)
+            .build()
+
+        XCTAssertEqual(config.logger.logLevel, .warn)
+    }
+
+}


### PR DESCRIPTION
### Summary
These changes provide users with more controls over the SDK logging behavior. Users can now provide their own logger instances via client configs.
### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
