### PR TITLE
feat: support multi-value array properties with non-set operators

### DIFF
--- a/Sources/Experiment/EvaluationEngine.swift
+++ b/Sources/Experiment/EvaluationEngine.swift
@@ -79,21 +79,23 @@ internal class EvaluationEngine {
     
     private func matchCondition(target: EvaluationTarget, condition: EvaluationCondition) -> Bool {
         let propValue = target.select(selector: condition.selector)
-        // We need special matching for null properties and set type prop values
-        // and operators. All other values are matched as strings, since the
-        // filter values are always strings.
         if propValue == nil {
             return matchNull(op: condition.op, filterValues: condition.values)
-        } else if (isSetOperator(op: condition.op)) {
-            guard let propValueStringList = coerceStringList(value: propValue) else {
-                return false
-            }
-            return matchSet(propValues: propValueStringList, op: condition.op, filterValues: condition.values)
         } else {
-            guard let propValueString = coerceString(value: propValue) else {
-                return false
+            let propValueStringList = coerceStringList(value: propValue)
+            if isSetOperator(op: condition.op) {
+                guard let propValueStringList = propValueStringList else {
+                    return false
+                }
+                return matchSet(propValues: propValueStringList, op: condition.op, filterValues: condition.values)
+            } else if let propValueStringList = propValueStringList {
+                return matchStringsNonSet(propValues: propValueStringList, op: condition.op, filterValues: condition.values)
+            } else {
+                guard let propValueString = coerceString(value: propValue) else {
+                    return false
+                }
+                return matchString(propValue: propValueString, op: condition.op, filterValues: condition.values)
             }
-            return matchString(propValue: propValueString, op: condition.op, filterValues: condition.values)
         }
     }
     
@@ -188,6 +190,12 @@ internal class EvaluationEngine {
         }
     }
     
+    private func matchStringsNonSet(propValues: Set<String>, op: String, filterValues: Set<String>) -> Bool {
+        return propValues.contains { element in
+            matchString(propValue: element, op: op, filterValues: filterValues)
+        }
+    }
+
     private func matchesIs(propValue: String, filterValues: Set<String>) -> Bool {
         if containsBooleans(filterValues: filterValues) {
             let lower = propValue.lowercased()
@@ -290,7 +298,10 @@ internal class EvaluationEngine {
         }
         // Parse the string value as a json array and convert to a set of strings
         // or return nil if the string could not be parsed as a json array.
-        guard let dataValue = coerceString(value: value)?.data(using: .utf8) else {
+        guard let stringValue = coerceString(value: value), stringValue.hasPrefix("[") else {
+            return nil
+        }
+        guard let dataValue = stringValue.data(using: .utf8) else {
             return nil
         }
         if let opt = try? JSONSerialization.jsonObject(with: dataValue) {

--- a/Tests/ExperimentTests/EvaluationEngineTests.swift
+++ b/Tests/ExperimentTests/EvaluationEngineTests.swift
@@ -1,0 +1,121 @@
+//
+//  EvaluationEngineTests.swift
+//  ExperimentTests
+//
+
+import XCTest
+@testable import Experiment
+
+class EvaluationEngineTests: XCTestCase {
+
+    let engine = EvaluationEngine()
+
+    // Scalar string tests
+
+    func testScalarStringIsMatch() {
+        assertMatch(propValue: "hello", op: EvaluationOperator.IS, values: ["hello"])
+    }
+
+    func testScalarStringContainsMatch() {
+        assertMatch(propValue: "hello", op: EvaluationOperator.CONTAINS, values: ["ell"])
+    }
+
+    func testScalarStringGreaterThanMatch() {
+        assertMatch(propValue: "2", op: EvaluationOperator.GREATER_THAN, values: ["1"])
+    }
+
+    func testScalarStringIsNoMatch() {
+        assertNoMatch(propValue: "world", op: EvaluationOperator.IS, values: ["hello"])
+    }
+
+    // Non-string scalar tests
+
+    func testNonStringScalarGreaterThan() {
+        assertMatch(propValue: 42, op: EvaluationOperator.GREATER_THAN, values: ["1"])
+    }
+
+    func testNonStringScalarIs() {
+        assertMatch(propValue: true, op: EvaluationOperator.IS, values: ["true"])
+    }
+
+    // JSON array string tests
+
+    func testJsonArrayStringSetOperator() {
+        assertMatch(propValue: "[\"a\",\"b\"]", op: EvaluationOperator.SET_CONTAINS, values: ["a"])
+    }
+
+    func testJsonArrayStringNonSetOperator() {
+        assertMatch(propValue: "[\"a\",\"b\"]", op: EvaluationOperator.IS, values: ["a"])
+    }
+
+    // Collection tests
+
+    func testCollectionSetOperator() {
+        assertMatch(propValue: ["a", "b"], op: EvaluationOperator.SET_CONTAINS, values: ["a"])
+    }
+
+    func testCollectionNonSetOperator() {
+        assertMatch(propValue: ["a", "b"], op: EvaluationOperator.IS, values: ["a"])
+    }
+
+    // Edge cases
+
+    func testMalformedJsonArrayFallsThrough() {
+        assertMatch(propValue: "[broken", op: EvaluationOperator.IS, values: ["[broken"])
+    }
+
+    func testEmptyJsonArraySetOperator() {
+        assertNoMatch(propValue: "[]", op: EvaluationOperator.SET_CONTAINS, values: ["a"])
+    }
+
+    func testLeadingWhitespaceNotParsedAsArray() {
+        assertMatch(propValue: " [\"a\"]", op: EvaluationOperator.IS, values: [" [\"a\"]"])
+    }
+
+    func testLeadingWhitespaceNotParsedAsArraySet() {
+        assertNoMatch(propValue: " [\"a\"]", op: EvaluationOperator.SET_CONTAINS, values: ["a"])
+    }
+}
+
+// Test helpers
+
+private let testFlagKey = "test-flag"
+
+private func flagWithCondition(op: String, values: Set<String>) -> EvaluationFlag {
+    return EvaluationFlag(
+        key: testFlagKey,
+        variants: ["on": EvaluationVariant(key: "on", value: nil, payload: nil, metadata: nil)],
+        segments: [
+            EvaluationSegment(
+                bucket: nil,
+                conditions: [[EvaluationCondition(selector: ["context", "user", "user_properties", "test_prop"], op: op, values: values)]],
+                variant: "on",
+                metadata: nil
+            )
+        ],
+        dependencies: nil,
+        metadata: nil
+    )
+}
+
+private func contextWithProp(value: Any?) -> [String: Any?] {
+    return ["user": ["user_properties": ["test_prop": value]]]
+}
+
+private func evaluate(propValue: Any?, op: String, values: Set<String>) -> EvaluationVariant? {
+    let flag = flagWithCondition(op: op, values: values)
+    let context = contextWithProp(value: propValue)
+    let engine = EvaluationEngine()
+    let results = engine.evaluate(context: context, flags: [flag])
+    return results[testFlagKey]
+}
+
+private func assertMatch(propValue: Any?, op: String, values: Set<String>, file: StaticString = #file, line: UInt = #line) {
+    let result = evaluate(propValue: propValue, op: op, values: values)
+    XCTAssertEqual("on", result?.key, file: file, line: line)
+}
+
+private func assertNoMatch(propValue: Any?, op: String, values: Set<String>, file: StaticString = #file, line: UInt = #line) {
+    let result = evaluate(propValue: propValue, op: op, values: values)
+    XCTAssertNil(result, file: file, line: line)
+}

--- a/Tests/ExperimentTests/EvaluationIntegrationTests.swift
+++ b/Tests/ExperimentTests/EvaluationIntegrationTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import Foundation
 @testable import Experiment
 
-private let DEPLOYMENT_KEY = "server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy"
+private let DEPLOYMENT_KEY = "server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh"
 
 private var flags: [EvaluationFlag] = []
 
@@ -451,6 +451,50 @@ class EvaluationIntegrationTests: XCTestCase {
         result = engine.evaluate(context: user, flags: flags)["test-is-with-booleans"]
         XCTAssertEqual("on", result?.key)
     }
+
+    // Multi-Value Array Property Tests
+
+    func testSetIsWithJsonArrayString() {
+        let user = userContext(userProperties: ["key": "[\"1\", \"2\", \"3\"]"])
+        let result = engine.evaluate(context: user, flags: flags)["test-set-is"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testIsWithArrayCollection() {
+        let user = userContext(userProperties: ["key": ["value1", "value2"]])
+        let result = engine.evaluate(context: user, flags: flags)["test-is-array"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testIsNotWithArray() {
+        let user = userContext(userProperties: ["key": ["value3", "value4"]])
+        let result = engine.evaluate(context: user, flags: flags)["test-is-not-array"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testContainsWithArray() {
+        let user = userContext(userProperties: ["key": ["has-target-value", "has", "value"]])
+        let result = engine.evaluate(context: user, flags: flags)["test-contains-array"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testDoesNotContainWithArray() {
+        let user = userContext(userProperties: ["key": ["has-value", "has", "value"]])
+        let result = engine.evaluate(context: user, flags: flags)["test-does-not-contain-array"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testIsWithJsonArrayString() {
+        let user = userContext(userProperties: ["key": "[\"value1\", \"value2\"]"])
+        let result = engine.evaluate(context: user, flags: flags)["test-is-array"]
+        XCTAssertEqual("on", result?.key)
+    }
+
+    func testDoesNotContainWithJsonArrayString() {
+        let user = userContext(userProperties: ["key": "[\"has-value\", \"has\", \"value\"]"])
+        let result = engine.evaluate(context: user, flags: flags)["test-does-not-contain-array"]
+        XCTAssertEqual("on", result?.key)
+    }
 }
 
 // Object utils
@@ -502,7 +546,6 @@ private func doFlagsAsync(_ completion: @escaping (Result<[EvaluationFlag], Erro
     request.httpMethod = "GET"
     request.setValue("Api-Key \(DEPLOYMENT_KEY)", forHTTPHeaderField: "Authorization")
     request.timeoutInterval = 20.0
-    // Do fetch request
     URLSession.shared.dataTask(with: request) { (data, response, error) in
         if let error = error {
             completion(Result.failure(error))

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -15,7 +15,7 @@ let KEY = "sdk-ci-test"
 let INITIAL_KEY = "initial-key"
 
 let testUser = ExperimentUserBuilder().userId("test_user").build()
-let serverVariant = Variant("on", payload: "payload", key: "on", metadata: ["evaluationId": ""])
+let serverVariant = Variant("on", payload: "payload", key: "on", metadata: ["evaluationId": "", "segmentName": ""])
 let fallbackVariant = Variant("fallback", payload: "payload")
 let initialVariant = Variant("initial")
 let initialVariants: [String: Variant] = [
@@ -28,6 +28,7 @@ let serverVariant2 = Variant("on", metadata: ["evaluationId": ""])
 func assertVariantEqual(expected: Variant, actual: Variant) {
     var metadata = expected.metadata ?? (actual.metadata != nil ? [:] : nil)
     metadata?["evaluationId"] = actual.metadata?["evaluationId"]
+    metadata?["segmentName"] = actual.metadata?["segmentName"]
     let matchedExpected = Variant(key: expected.key, value: expected.value, payload: expected.payload, expKey: expected.expKey, metadata: metadata)
     XCTAssertEqual(matchedExpected, actual)
 }

--- a/Tests/ExperimentTests/ObjectiveCTest.m
+++ b/Tests/ExperimentTests/ObjectiveCTest.m
@@ -16,6 +16,7 @@ void assertVariantEqualExpected(Variant *expected, Variant *actual) {
     }
     if (metadata != nil && actual.metadata != nil) {
         metadata[@"evaluationId"] = actual.metadata[@"evaluationId"];
+        metadata[@"segmentName"] = actual.metadata[@"segmentName"];
     }
     
     Variant *matchedExpected = [[Variant alloc] init:expected.value payload:expected.payload expKey:expected.expKey key:expected.key metadata:metadata];


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment iOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Update evaluation engine to support multi-value array properties with non-set operators to match filtering/segmentation of charts/analytics.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag targeting semantics by allowing array/JSON-array properties to satisfy non-set operators, which could alter experiment rollout results for existing users if they have multi-value properties. Added tests reduce risk but behavior changes warrant careful review.
> 
> **Overview**
> **Adds support for multi-value properties with non-set operators.** `EvaluationEngine.matchCondition` now treats array-like property values (native collections or JSON array strings) as *multi-valued* and considers a condition matched if **any element** matches the operator (e.g., `IS`, `CONTAINS`, comparisons), while still preserving set-operator behavior via `matchSet`.
> 
> Tightens `coerceStringList` parsing to only attempt JSON-array parsing when the string begins with `[` (so malformed/whitespace-prefixed strings fall back to scalar matching), and adds new unit + integration tests covering arrays/JSON arrays and edge cases. Test expectations were updated to include `segmentName` metadata and the integration deployment key was rotated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2967cea52698aa9f13c05ac83737a9acbf8b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->