### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash - fix skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [authorize]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set Xcode 16.3
         run: |


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via [automated scripts](https://github.com/amplitude/tools/tree/master/seceng/github_actions/pin-gha).
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 4/10/2026.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins `actions/checkout` in the release workflow to a specific commit SHA, which should not change behavior aside from improving supply-chain integrity.
> 
> **Overview**
> Pins the `actions/checkout` step in `.github/workflows/release.yml` from the floating `v4` tag to a full commit SHA, tightening GitHub Actions supply-chain security for the Release pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53812ee67a402042e25fa75e67240f44825d605c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->