### PR TITLE
ci: initialize CoreSimulator before downloading runtimes in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,15 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_16.3.app
           xcodebuild -runFirstLaunch
 
-      - name: Download iOS Simulator Runtime
-        run: xcodebuild -downloadPlatform iOS
+      - name: Install iOS Simulator Runtime
+        run: |
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
 
-      - name: Download tvOS Simulator Runtime
-        run: xcodebuild -downloadPlatform tvOS
+      - name: Install tvOS Simulator Runtime
+        run: |
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform tvOS
 
       - name: Carthage Bootstrap
         run: carthage bootstrap --use-xcframeworks


### PR DESCRIPTION
## Summary

The most recent Release run ([25080142916](https://github.com/amplitude/experiment-ios-client/actions/runs/25080142916)) failed at the test job's "Download iOS Simulator Runtime" step:

```
$ xcodebuild -downloadPlatform iOS
Unable to connect to simulator.
##[error]Process completed with exit code 70.
```

On `macos-15` runners, `xcodebuild -downloadPlatform` cannot connect unless CoreSimulator has been warmed up via `xcrun simctl list`, and the download itself requires `sudo`. `test.yml` already uses that pattern (added in `616dc53`); this PR ports the same pattern into `release.yml` so the test job in the release workflow stops hitting the unconnected-simulator path.

Diff is two steps in `release.yml`:
- `Download iOS Simulator Runtime` → `Install iOS Simulator Runtime` with `xcrun simctl list` warmup + `sudo`
- `Download tvOS Simulator Runtime` → same fix for tvOS

## Test plan

- [ ] Trigger Release with `dryRun=true` after merge — test job should complete past the simulator-runtime steps.
- [ ] Confirm iOS / macOS / tvOS test steps still run as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change limited to release workflow runtime install steps; low risk aside from potential runner/environment differences when invoking `sudo xcodebuild`.
> 
> **Overview**
> Fixes release workflow flakiness on `macos-15` by warming up CoreSimulator before downloading simulator runtimes.
> 
> In `.github/workflows/release.yml`, the iOS and tvOS runtime download steps are replaced with “Install * Simulator Runtime” steps that run `xcrun simctl list` and use `sudo xcodebuild -downloadPlatform ...` for both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7b8f243a6a5b255ae7d28437a66465fd2c8c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->