### PR TITLE
ci: split release test job into per-platform matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    name: Test
+    name: Test (${{ matrix.platform }})
     runs-on: macos-15
     needs: [authorize]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: iOS
+            sdk: iphonesimulator
+            destination: 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+            download-runtime: iOS
+          - platform: macOS
+            sdk: macosx
+            destination: 'platform=macOS'
+            download-runtime: ''
+          - platform: tvOS
+            sdk: appletvsimulator
+            destination: 'platform=tvOS Simulator,name=Apple TV,OS=latest'
+            download-runtime: tvOS
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -34,44 +50,24 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_16.3.app
           xcodebuild -runFirstLaunch
 
-      - name: Install iOS Simulator Runtime
+      - name: Install Simulator Runtime
+        if: matrix.download-runtime != ''
         run: |
           xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform iOS
-
-      - name: Install tvOS Simulator Runtime
-        run: |
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform ${{ matrix.download-runtime }}
 
       - name: Carthage Bootstrap
         run: carthage bootstrap --use-xcframeworks
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: iOS Tests
+      - name: Run Tests
         run: |
           xcodebuild test \
             -project Experiment.xcodeproj \
             -scheme Experiment \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
-
-      - name: macOS Tests
-        run: |
-          xcodebuild test \
-            -project Experiment.xcodeproj \
-            -scheme Experiment \
-            -sdk macosx \
-            -destination 'platform=macOS'
-
-      - name: tvOS Tests
-        run: |
-          xcodebuild test \
-            -project Experiment.xcodeproj \
-            -scheme Experiment \
-            -sdk appletvsimulator \
-            -destination 'platform=tvOS Simulator,name=Apple TV,OS=latest'
+            -sdk ${{ matrix.sdk }} \
+            -destination '${{ matrix.destination }}'
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,16 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform watchOS
+          sudo xcodebuild -downloadPlatform visionOS
+
       - name: Validate Podfile
         run: pod lib lint --allow-warnings --verbose
 


### PR DESCRIPTION
## Summary
- `release.yml`'s `test` job ran iOS, macOS, and tvOS sequentially on a single runner. Convert it to a matrix mirroring `test.yml` so each platform gets a fresh runner.
- The shared-runner setup was masking a flaky SIGSEGV on macOS: a background storage queue closure outliving the test method ([crash in `InMemoryStorage.put`](https://github.com/amplitude/experiment-ios-client/actions/runs/25134427054)). It only manifested in the release workflow; `test.yml`'s matrix has been green on the same code.
- `fail-fast: false` so one platform's flake doesn't kill the others.
- The `release` job's `needs: [test]` still gates on all three matrix legs.

## Test plan
- [ ] Workflow YAML parses (no syntax errors on push).
- [ ] Trigger a `workflow_dispatch` run with `dryRun=true` and verify all three matrix legs run in parallel and pass.
- [ ] Confirm the `release` job runs only after all three test legs succeed.

Note: this does not fix the underlying race in `LoadStoreCache.store(async:)` / `InMemoryStorage` thread-safety — that's a separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it alters release gating behavior by changing how/when platform tests run and download simulator runtimes.
> 
> **Overview**
> Updates `release.yml` to run the `test` job as a per-platform matrix (iOS, macOS, tvOS) instead of sequential steps on a single runner, with `fail-fast: false` and per-platform `sdk`/`destination` parameters.
> 
> Refactors simulator runtime installation into a conditional step driven by matrix metadata, and adds a release-step to pre-download additional Apple platform SDKs (iOS/tvOS/watchOS/visionOS) before validation and semantic release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7380da0fed42ebd507d2b1aa36a555e9231a081f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->