### PR TITLE
ci: add visionOS to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
             download-runtime: tvOS
           - platform: visionOS
             sdk: xrsimulator
-            destination: 'platform=visionOS Simulator,name=Apple Vision Pro,OS=latest'
+            # Pin OS: macos-15 has both visionOS 2.x and 26.x installed,
+            # which makes OS=latest ambiguous and fails destination matching.
+            destination: 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5'
             download-runtime: visionOS
     name: test (${{ matrix.platform }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
             sdk: appletvsimulator
             destination: 'platform=tvOS Simulator,name=Apple TV,OS=latest'
             download-runtime: tvOS
+          - platform: visionOS
+            sdk: xrsimulator
+            destination: 'platform=visionOS Simulator,name=Apple Vision Pro,OS=latest'
+            download-runtime: visionOS
     name: test (${{ matrix.platform }})
     steps:
       - name: Checkout 


### PR DESCRIPTION
## Summary
- The podspec advertises visionOS support (`spec.visionos.deployment_target = '1.0'`) but visionOS has never been built or tested in CI.
- Adds a visionOS Simulator leg to `test.yml`'s matrix so the suite catches breakage on that platform before it reaches `pod lib lint` in the release job.

## Test plan
- [ ] Push triggers all four matrix legs (iOS / macOS / tvOS / visionOS); confirm the visionOS leg downloads the visionOS runtime and tests pass.
- [ ] If the visionOS leg fails, decide whether to fix the source or trim the podspec — flag for follow-up.

## Notes
- `Package.swift` still does not declare visionOS — that's a separate gap. If the visionOS leg is green here, a follow-up to align Package.swift with the podspec makes sense.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands the test matrix; main risk is longer CI times or flaky runs due to simulator/runtime availability and destination pinning.
> 
> **Overview**
> Adds a **visionOS** leg to the GitHub Actions `Test` workflow matrix so the existing `xcodebuild test` step runs against the visionOS simulator as well.
> 
> The visionOS destination is pinned to `Apple Vision Pro, OS=2.5` (instead of `OS=latest`) to avoid ambiguous destination matching on `macos-15`, and the job will download the visionOS simulator runtime before testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d80f844c92f98f74827b1754e8b8d8889195f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->