### PR TITLE
fix(Murmur3): Update `Murmur3` to return `UInt32` to avoid crashes on `watchOS`.

### DIFF
--- a/Sources/Experiment/Murmur3.swift
+++ b/Sources/Experiment/Murmur3.swift
@@ -15,14 +15,14 @@ private let M_32: UInt32 = 5
 private let N_32: UInt32 = UInt32(bitPattern: -0x19ab949c)
 
 internal extension String {
-    func murmurHash32x86(seed: Int) -> Int? {
+    func murmurHash32x86(seed: Int) -> UInt32? {
         self.data(using: .utf8)?.murmurHash32x86(seed: seed)
     }
 }
 
 internal extension Data {
     
-    func murmurHash32x86(seed: Int) -> Int {
+    func murmurHash32x86(seed: Int) -> UInt32 {
         let length = self.count
         var hash = UInt32(seed)
         let nBlocks = length >> 2
@@ -66,7 +66,7 @@ internal extension Data {
             break
         }
         hash ^= UInt32(length)
-        return Int(fmix32(hash: hash))
+        return fmix32(hash: hash)
     }
 }
 

--- a/Tests/ExperimentTests/Murmur3Tests.swift
+++ b/Tests/ExperimentTests/Murmur3Tests.swift
@@ -24,7 +24,7 @@ class Murmur3Tests: XCTestCase {
         let outputs = MURMUR3_X86_32.split(separator: "\n")
         for i in 0..<inputs.count {
             let input = String(inputs[i])
-            let output = Int(outputs[i])
+            let output = UInt32(outputs[i])
             let result = input.murmurHash32x86(seed: MURMUR_SEED)
             XCTAssertEqual(result, output)
         }


### PR DESCRIPTION
# Summary
Hi!
This PR fixes a crash in `Murmur3` which happen when running experiments on `watchOS` when running on `arm64_32`. `arm64_32` is still used by a lot of watches, even on recent `watchOS` versions such as 26.4.

## Root cause/solution

On `arm64_32`, `Int` is only 32 bits wide, this means that the current implementation of `Murmur3` will overflow and crash for some values. Switching this to just return `UInt32` directly solves the issue, and doesn't have any negative consequences since the hash-value is inherently unsigned.

## Reproduction
Unfortunately we haven't been able to reproduce this crash, nor create any convincing testcases, since it seems impossible to simulate the environment where `Int` is only 32 bit wide. And we don't posses any hardware/os combo running that either, we're however fairly confident that this solution is the correct way forward.

We've also seen this crash for hundreds of our users on various watches running `watchOS` 26.4 and lower.

## Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ios-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  `no`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the return type of `murmurHash32x86` from `Int` to `UInt32`, which can require downstream call-site updates even though it prevents overflow/crashes on 32-bit `Int` platforms (e.g., `arm64_32`).
> 
> **Overview**
> Updates Murmur3 32-bit hashing helpers to return `UInt32` instead of `Int`, avoiding overflow when `Int` is 32-bit (notably on `watchOS` `arm64_32`).
> 
> Adjusts tests to compare expected values as `UInt32` to match the new API and preserve existing hash outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b92b978172d2965bc40d1380a0578ffdecbac05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->