### PR TITLE
fix: SKY-32 reset exposure dedup cache on user identity change

### DIFF
--- a/Sources/Experiment/ExperimentClient.swift
+++ b/Sources/Experiment/ExperimentClient.swift
@@ -681,7 +681,8 @@ internal class DefaultExperimentClient : NSObject, ExperimentClient {
         if !fallback && !variantAndSource.variant.isDefaultVariant() {
             exposureVariant = variantAndSource.variant.key ?? variantAndSource.variant.value
         }
-        userSessionExposureTracker.track(exposure: Exposure(flagKey: key, variant: exposureVariant, experimentKey: variantAndSource.variant.expKey, metadata: variantAndSource.variant.metadata))
+        let exposureUser = mergeUserWithProvider()
+        userSessionExposureTracker.track(exposure: Exposure(flagKey: key, variant: exposureVariant, experimentKey: variantAndSource.variant.expKey, metadata: variantAndSource.variant.metadata), user: exposureUser)
     }
     
     private func legacyExposureInternal(key: String, variantAndSource: VariantAndSource) {

--- a/Tests/ExperimentTests/ExperimentClientTests.swift
+++ b/Tests/ExperimentTests/ExperimentClientTests.swift
@@ -1354,6 +1354,107 @@ class ExperimentClientTests: XCTestCase {
         XCTAssertEqual(storedOption, "track")
     }
     
+    // Exposure dedup reset tests (mirrors Android PR #77)
+
+    func testExposureDedup_ResetsOnUserIdChange() {
+        let exposureTrackingProvider = TestExposureTrackingProvider()
+        let client = DefaultExperimentClient(
+            apiKey: API_KEY,
+            config: ExperimentConfigBuilder()
+                .exposureTrackingProvider(exposureTrackingProvider)
+                .source(.LocalStorage)
+                .build(),
+            storage: InMemoryStorage()
+        )
+        let flagKey = "test-dedup-flag"
+        client.variants.put(key: flagKey, value: Variant(key: "on", value: "on"))
+
+        let userA = ExperimentUserBuilder().userId("userA").build()
+        client.setUser(userA)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount, "User A should trigger first exposure")
+
+        _ = client.variant(flagKey)
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount, "Same user and variant should be deduped")
+
+        let userB = ExperimentUserBuilder().userId("userB").build()
+        client.setUser(userB)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(2, exposureTrackingProvider.trackCount, "User B on same flag should fire a new exposure")
+    }
+
+    func testExposureDedup_ResetsOnDeviceIdChange() {
+        let exposureTrackingProvider = TestExposureTrackingProvider()
+        let client = DefaultExperimentClient(
+            apiKey: API_KEY,
+            config: ExperimentConfigBuilder()
+                .exposureTrackingProvider(exposureTrackingProvider)
+                .source(.LocalStorage)
+                .build(),
+            storage: InMemoryStorage()
+        )
+        let flagKey = "test-dedup-flag"
+        client.variants.put(key: flagKey, value: Variant(key: "on", value: "on"))
+
+        let deviceA = ExperimentUserBuilder().deviceId("deviceA").build()
+        client.setUser(deviceA)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount, "Device A should trigger first exposure")
+
+        _ = client.variant(flagKey)
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount, "Same device and variant should be deduped")
+
+        let deviceB = ExperimentUserBuilder().deviceId("deviceB").build()
+        client.setUser(deviceB)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(2, exposureTrackingProvider.trackCount, "Device B on same flag should fire a new exposure")
+    }
+
+    func testExposureDedup_DoesNotResetWhenUserUnchanged() {
+        let exposureTrackingProvider = TestExposureTrackingProvider()
+        let client = DefaultExperimentClient(
+            apiKey: API_KEY,
+            config: ExperimentConfigBuilder()
+                .exposureTrackingProvider(exposureTrackingProvider)
+                .source(.LocalStorage)
+                .build(),
+            storage: InMemoryStorage()
+        )
+        let flagKey = "test-dedup-flag"
+        client.variants.put(key: flagKey, value: Variant(key: "on", value: "on"))
+
+        let user = ExperimentUserBuilder().userId("userA").deviceId("deviceA").build()
+        client.setUser(user)
+        for _ in 0...5 {
+            _ = client.variant(flagKey)
+        }
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount, "Same user should deduplicate repeated exposures")
+    }
+
+    func testExposureDedup_ResetsOnUserIdAndDeviceIdChange() {
+        let exposureTrackingProvider = TestExposureTrackingProvider()
+        let client = DefaultExperimentClient(
+            apiKey: API_KEY,
+            config: ExperimentConfigBuilder()
+                .exposureTrackingProvider(exposureTrackingProvider)
+                .source(.LocalStorage)
+                .build(),
+            storage: InMemoryStorage()
+        )
+        let flagKey = "test-dedup-flag"
+        client.variants.put(key: flagKey, value: Variant(key: "on", value: "on"))
+
+        let userA = ExperimentUserBuilder().userId("userA").deviceId("deviceA").build()
+        client.setUser(userA)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(1, exposureTrackingProvider.trackCount)
+
+        let userB = ExperimentUserBuilder().userId("userB").deviceId("deviceB").build()
+        client.setUser(userB)
+        _ = client.variant(flagKey)
+        XCTAssertEqual(2, exposureTrackingProvider.trackCount, "Changing both userId and deviceId should reset dedup cache")
+    }
+
     func testMultipleCallsToSetTracksAssignmentUsesLatestSetting() {
         let client = DefaultExperimentClient(
             apiKey: API_KEY,


### PR DESCRIPTION
## Summary

- **Bug:** `exposureInternal` called `userSessionExposureTracker.track(exposure:)` without passing the current user. Because `user:` was always `nil`, the tracker's identity was always `null == null`, so the dedup cache never cleared on user change. On a shared device, User B silently received no exposure events for flags already seen by User A.
- **Fix:** Resolve the current user via `mergeUserWithProvider()` and forward it as the `user:` argument to `track(exposure:user:)` — a one-line change directly analogous to the Android fix.
- **Tests:** Four new integration tests in `ExperimentClientTests` mirroring the Android test coverage: dedup resets on userId change, deviceId change, both changing together, and dedup still holds when the user is unchanged.

## Root cause

This is the same regression introduced in the Android SDK in commit `b512971e` ("feat: local evaluation", [#38](https://github.com/amplitude/experiment-android-client/issues/38)), where a refactor split the exposure tracking path but forgot to forward the resolved user to the new tracker call site.

The Android fix was merged in [experiment-android-client#77](https://github.com/amplitude/experiment-android-client/pull/77):
```kotlin
// Android fix (DefaultExperimentClient.kt:306)
userSessionExposureTracker?.track(exposure, getUserMergedWithProvider())
```

This PR applies the equivalent fix to iOS:
```swift
// Before
userSessionExposureTracker.track(exposure: Exposure(...))

// After
let exposureUser = mergeUserWithProvider()
userSessionExposureTracker.track(exposure: Exposure(...), user: exposureUser)
```

## Test plan

- [ ] `testExposureDedup_ResetsOnUserIdChange` — User A gets exposure, userId changes to User B, same flag fires again
- [ ] `testExposureDedup_ResetsOnDeviceIdChange` — same as above but for deviceId
- [ ] `testExposureDedup_ResetsOnUserIdAndDeviceIdChange` — both identity fields change simultaneously
- [ ] `testExposureDedup_DoesNotResetWhenUserUnchanged` — sanity check that dedup still suppresses repeated exposures for the same user

Ref: https://github.com/amplitude/experiment-android-client/pull/77

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQg4MywazVwdcEUeKk79Ev)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exposure tracking behavior by associating exposures with the resolved user identity, which can increase exposure event volume and affect analytics for shared-device scenarios. Scope is small and covered by new tests, but touches core tracking logic.
> 
> **Overview**
> Fixes a regression where exposure deduplication never reset on user changes by passing the resolved user (`mergeUserWithProvider()`) into `UserSessionExposureTracker.track(exposure:user:)` from `exposureInternal`.
> 
> Adds integration tests ensuring the dedup cache resets when `userId` and/or `deviceId` changes, and still deduplicates repeated exposures when identity is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e56b9f8b798b77e0959f2efa8282d688486711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->